### PR TITLE
[cherry-pick] Expose column family id to OnCompactionCompleted (#4466)

### DIFF
--- a/db/db_impl_compaction_flush.cc
+++ b/db/db_impl_compaction_flush.cc
@@ -785,6 +785,7 @@ void DBImpl::NotifyOnCompactionCompleted(
   TEST_SYNC_POINT("DBImpl::NotifyOnCompactionCompleted::UnlockMutex");
   {
     CompactionJobInfo info;
+    info.cf_id = cfd->GetID();
     info.cf_name = cfd->GetName();
     info.status = st;
     info.thread_id = env_->GetThreadID();

--- a/include/rocksdb/listener.h
+++ b/include/rocksdb/listener.h
@@ -175,6 +175,8 @@ struct CompactionJobInfo {
   explicit CompactionJobInfo(const CompactionJobStats& _stats) :
       stats(_stats) {}
 
+  // the id of the column family where the compaction happened.
+  uint32_t cf_id;
   // the name of the column family where the compaction happened.
   std::string cf_name;
   // the status indicating whether the compaction was successful or not.


### PR DESCRIPTION
Summary:
The controller you requested could not be found. PTAL
Pull Request resolved: https://github.com/facebook/rocksdb/pull/4466

Differential Revision: D10241358

Pulled By: yiwu-arbug

fbshipit-source-id: 99664eb286860a6c8844d50efeb0ef6f0e10dd1e

# Conflicts:
#	HISTORY.md