### PR TITLE
Fix build error when build wihtout openssl

### DIFF
--- a/tools/db_bench_tool.cc
+++ b/tools/db_bench_tool.cc
@@ -6497,6 +6497,7 @@ int db_bench_tool(int argc, char** argv) {
     FLAGS_env = new rocksdb::HdfsEnv(FLAGS_hdfs);
   }
 
+#ifdef OPENSSL
   if (!FLAGS_encryption_method.empty()) {
     encryption::EncryptionMethod method =
         encryption::EncryptionMethod::kUnknown;
@@ -6516,6 +6517,7 @@ int db_bench_tool(int argc, char** argv) {
         new encryption::InMemoryKeyManager(method));
     FLAGS_env = encryption::NewKeyManagedEncryptedEnv(FLAGS_env, key_manager);
   }
+#endif // OPENSSL
 
   if (!strcasecmp(FLAGS_compaction_fadvice.c_str(), "NONE"))
     FLAGS_compaction_fadvice_e = rocksdb::Options::NONE;


### PR DESCRIPTION
Summary:
Fix missing check for openssl in db_bench.

Test Plan:
build without openssl

Signed-off-by: Yi Wu <yiwu@pingcap.com>