### PR TITLE
[BUG] Pass enable_multi_thread_write to BuildDBOptions

### DIFF
--- a/options/options_helper.cc
+++ b/options/options_helper.cc
@@ -105,6 +105,7 @@ DBOptions BuildDBOptions(const ImmutableDBOptions& immutable_db_options,
   options.enable_thread_tracking = immutable_db_options.enable_thread_tracking;
   options.delayed_write_rate = mutable_db_options.delayed_write_rate;
   options.enable_pipelined_write = immutable_db_options.enable_pipelined_write;
+  options.enable_multi_thread_write = immutable_db_options.enable_multi_thread_write;
   options.unordered_write = immutable_db_options.unordered_write;
   options.allow_concurrent_memtable_write =
       immutable_db_options.allow_concurrent_memtable_write;


### PR DESCRIPTION
This is a bug that I did not pass `enable_multi_thread_write` to the function `BuildDBOptions`, which may cause some case we can not get the right value of `enable_multi_thread_write`  from `DBOptions`