### PR TITLE
[DNM] SST Partitioner interface that allows to split SST files

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -507,6 +507,7 @@ set(SOURCES
         db/compaction/compaction_picker_fifo.cc
         db/compaction/compaction_picker_level.cc
         db/compaction/compaction_picker_universal.cc
+        db/compaction/sst_partitioner.cc
         db/convenience.cc
         db/db_filesnapshot.cc
         db/db_impl/db_impl.cc

--- a/db/compaction/compaction.cc
+++ b/db/compaction/compaction.cc
@@ -7,12 +7,14 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file. See the AUTHORS file for names of contributors.
 
+#include "db/compaction/compaction.h"
+
 #include <cinttypes>
 #include <vector>
 
 #include "db/column_family.h"
-#include "db/compaction/compaction.h"
 #include "rocksdb/compaction_filter.h"
+#include "rocksdb/sst_partitioner.h"
 #include "test_util/sync_point.h"
 #include "util/string_util.h"
 
@@ -330,6 +332,8 @@ bool Compaction::IsTrivialMove() const {
 
   // assert inputs_.size() == 1
 
+  std::unique_ptr<SstPartitioner> partitioner = CreateSstPartitioner();
+
   for (const auto& file : inputs_.front().files) {
     std::vector<FileMetaData*> file_grand_parents;
     if (output_level_ + 1 >= number_levels_) {
@@ -341,6 +345,13 @@ bool Compaction::IsTrivialMove() const {
         file->fd.GetFileSize() + TotalFileSize(file_grand_parents);
     if (compaction_size > max_compaction_bytes_) {
       return false;
+    }
+
+    if (partitioner.get() != nullptr) {
+      partitioner->Reset(file->smallest.user_key());
+      if (partitioner->ShouldPartition(file->largest.user_key())) {
+        return false;
+      }
     }
   }
 
@@ -525,6 +536,19 @@ std::unique_ptr<CompactionFilter> Compaction::CreateCompactionFilter() const {
   context.is_bottommost_level = bottommost_level_;
   context.column_family_id = cfd_->GetID();
   return cfd_->ioptions()->compaction_filter_factory->CreateCompactionFilter(
+      context);
+}
+
+std::unique_ptr<SstPartitioner> Compaction::CreateSstPartitioner() const {
+  if (!immutable_cf_options_.sst_partitioner_factory) {
+    return nullptr;
+  }
+
+  SstPartitioner::Context context;
+  context.is_full_compaction = is_full_compaction_;
+  context.is_manual_compaction = is_manual_compaction_;
+  context.output_level = output_level_;
+  return immutable_cf_options_.sst_partitioner_factory->CreatePartitioner(
       context);
 }
 

--- a/db/compaction/compaction.cc
+++ b/db/compaction/compaction.cc
@@ -533,7 +533,7 @@ std::unique_ptr<CompactionFilter> Compaction::CreateCompactionFilter() const {
 }
 
 std::unique_ptr<SstPartitioner> Compaction::CreateSstPartitioner() const {
-  if (!immutable_cf_options_.sst_partitioner_factory) {
+  if (!immutable_cf_options_.sst_partitioner_factory || output_level_ == 0) {
     return nullptr;
   }
 

--- a/db/compaction/compaction.cc
+++ b/db/compaction/compaction.cc
@@ -346,13 +346,6 @@ bool Compaction::IsTrivialMove() const {
     if (compaction_size > max_compaction_bytes_) {
       return false;
     }
-
-    if (partitioner.get() != nullptr) {
-      partitioner->Reset(file->smallest.user_key());
-      if (partitioner->ShouldPartition(file->largest.user_key())) {
-        return false;
-      }
-    }
   }
 
   return true;
@@ -548,6 +541,8 @@ std::unique_ptr<SstPartitioner> Compaction::CreateSstPartitioner() const {
   context.is_full_compaction = is_full_compaction_;
   context.is_manual_compaction = is_manual_compaction_;
   context.output_level = output_level_;
+  context.smallest_key = smallest_user_key_.ToString();
+  context.largest_key = largest_user_key_.ToString();
   return immutable_cf_options_.sst_partitioner_factory->CreatePartitioner(
       context);
 }

--- a/db/compaction/compaction.h
+++ b/db/compaction/compaction.h
@@ -11,6 +11,7 @@
 #include "db/version_set.h"
 #include "memory/arena.h"
 #include "options/cf_options.h"
+#include "rocksdb/sst_partitioner.h"
 #include "util/autovector.h"
 
 namespace rocksdb {
@@ -254,6 +255,9 @@ class Compaction {
 
   // Create a CompactionFilter from compaction_filter_factory
   std::unique_ptr<CompactionFilter> CreateCompactionFilter() const;
+
+  // Create a SstPartitioner from sst_partitioner_factory
+  std::unique_ptr<SstPartitioner> CreateSstPartitioner() const;
 
   // Is the input level corresponding to output_level_ empty?
   bool IsOutputLevelEmpty() const;

--- a/db/compaction/compaction_picker_test.cc
+++ b/db/compaction/compaction_picker_test.cc
@@ -1414,6 +1414,31 @@ TEST_F(CompactionPickerTest, IsTrivialMoveOn) {
   ASSERT_TRUE(compaction->IsTrivialMove());
 }
 
+TEST_F(CompactionPickerTest, IsTrivialMoveOffSstPartitioned) {
+  mutable_cf_options_.max_bytes_for_level_base = 10000u;
+  mutable_cf_options_.max_compaction_bytes = 10001u;
+  ioptions_.level_compaction_dynamic_level_bytes = false;
+  ioptions_.sst_partitioner_factory = NewSstPartitionerFixedPrefixFactory(1);
+  NewVersionStorage(6, kCompactionStyleLevel);
+  // A compaction should be triggered and pick file 2
+  Add(1, 1U, "100", "150", 3000U);
+  Add(1, 2U, "151", "200", 3001U);
+  Add(1, 3U, "201", "250", 3000U);
+  Add(1, 4U, "251", "300", 3000U);
+
+  Add(3, 5U, "120", "130", 7000U);
+  Add(3, 6U, "170", "180", 7000U);
+  Add(3, 7U, "220", "230", 7000U);
+  Add(3, 8U, "270", "280", 7000U);
+  UpdateVersionStorageInfo();
+
+  std::unique_ptr<Compaction> compaction(level_compaction_picker.PickCompaction(
+      cf_name_, mutable_cf_options_, vstorage_.get(), &log_buffer_));
+  ASSERT_TRUE(compaction.get() != nullptr);
+  // No trivial move, because partitioning is applied
+  ASSERT_TRUE(!compaction->IsTrivialMove());
+}
+
 TEST_F(CompactionPickerTest, IsTrivialMoveOff) {
   mutable_cf_options_.max_bytes_for_level_base = 1000000u;
   mutable_cf_options_.max_compaction_bytes = 10000u;

--- a/db/compaction/sst_partitioner.cc
+++ b/db/compaction/sst_partitioner.cc
@@ -1,0 +1,63 @@
+//  Copyright (c) 2011-present, Facebook, Inc.  All rights reserved.
+//  This source code is licensed under both the GPLv2 (found in the
+//  COPYING file in the root directory) and Apache 2.0 License
+//  (found in the LICENSE.Apache file in the root directory).
+//
+// Copyright (c) 2011 The LevelDB Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file. See the AUTHORS file for names of contributors.
+
+#include "rocksdb/slice.h"
+#include "rocksdb/sst_partitioner.h"
+
+namespace rocksdb {
+class SstPartitionerFixedPrefix : public SstPartitioner {
+ public:
+  SstPartitionerFixedPrefix(size_t len) : len_(len) {}
+
+  virtual ~SstPartitionerFixedPrefix(){};
+
+  const char* Name() const override { return "SstPartitionerFixedPrefix"; }
+
+  bool ShouldPartition(const State& state) override {
+    if (last_key_.empty()) {
+      return false;
+    }
+    Slice key_fixed(state.next_key.data_, std::min(state.next_key.size_, len_));
+    return key_fixed.compare(last_key_) != 0;
+  }
+
+  void Reset(const Slice& key) override {
+    last_key_.assign(key.data_, std::min(key.size_, len_));
+  }
+
+ private:
+  size_t len_;
+  std::string last_key_;
+};
+
+class SstPartitionerFixedPrefixFactory : public SstPartitionerFactory {
+ public:
+  SstPartitionerFixedPrefixFactory(size_t len) : len_(len) {}
+
+  virtual ~SstPartitionerFixedPrefixFactory() {}
+
+  const char* Name() const override {
+    return "SstPartitionerFixedPrefixFactory";
+  }
+
+  std::unique_ptr<SstPartitioner> CreatePartitioner(
+      const SstPartitioner::Context& /* context */) const override {
+    return std::unique_ptr<SstPartitioner>(new SstPartitionerFixedPrefix(len_));
+  }
+
+ private:
+  size_t len_;
+};
+
+std::shared_ptr<SstPartitionerFactory> NewSstPartitionerFixedPrefixFactory(
+    size_t prefix_len) {
+  return std::make_shared<SstPartitionerFixedPrefixFactory>(prefix_len);
+}
+
+} // namespace rocksdb

--- a/db/db_compaction_test.cc
+++ b/db/db_compaction_test.cc
@@ -907,6 +907,60 @@ TEST_F(DBCompactionTest, UserKeyCrossFile2) {
   ASSERT_EQ("NOT_FOUND", Get("3"));
 }
 
+TEST_F(DBCompactionTest, CompactionSstPartitioner) {
+  Options options = CurrentOptions();
+  options.compaction_style = kCompactionStyleLevel;
+  options.level0_file_num_compaction_trigger = 3;
+  std::shared_ptr<SstPartitionerFactory> factory(
+      NewSstPartitionerFixedPrefixFactory(4));
+  options.sst_partitioner_factory = factory;
+
+  DestroyAndReopen(options);
+
+  // create first file and flush to l0
+  Put("aaaa1", "A");
+  Put("bbbb1", "B");
+  Flush();
+  dbfull()->TEST_WaitForFlushMemTable();
+
+  Put("aaaa1", "A2");
+  Flush();
+  dbfull()->TEST_WaitForFlushMemTable();
+
+  // move both files down to l1
+  dbfull()->CompactRange(CompactRangeOptions(), nullptr, nullptr);
+
+  std::vector<LiveFileMetaData> files;
+  dbfull()->GetLiveFilesMetaData(&files);
+  ASSERT_EQ(2, files.size());
+  ASSERT_EQ("A2", Get("aaaa1"));
+  ASSERT_EQ("B", Get("bbbb1"));
+}
+
+TEST_F(DBCompactionTest, CompactionSstPartitionerNonTrivial) {
+  Options options = CurrentOptions();
+  options.compaction_style = kCompactionStyleLevel;
+  options.level0_file_num_compaction_trigger = 1;
+  std::shared_ptr<SstPartitionerFactory> factory(
+      NewSstPartitionerFixedPrefixFactory(4));
+  options.sst_partitioner_factory = factory;
+
+  DestroyAndReopen(options);
+
+  // create first file and flush to l0
+  Put("aaaa1", "A");
+  Put("bbbb1", "B");
+  Flush();
+  dbfull()->TEST_WaitForFlushMemTable();
+  dbfull()->TEST_WaitForCompact(true);
+
+  std::vector<LiveFileMetaData> files;
+  dbfull()->GetLiveFilesMetaData(&files);
+  ASSERT_EQ(2, files.size());
+  ASSERT_EQ("A", Get("aaaa1"));
+  ASSERT_EQ("B", Get("bbbb1"));
+}
+
 TEST_F(DBCompactionTest, ZeroSeqIdCompaction) {
   Options options = CurrentOptions();
   options.compaction_style = kCompactionStyleLevel;

--- a/include/rocksdb/options.h
+++ b/include/rocksdb/options.h
@@ -48,6 +48,7 @@ class Slice;
 class Statistics;
 class InternalKeyComparator;
 class WalFilter;
+class SstPartitionerFactory;
 
 // DB contents are stored in a set of blocks, each of which holds a
 // sequence of key,value pairs.  Each block may be compressed before
@@ -315,6 +316,14 @@ struct ColumnFamilyOptions : public AdvancedColumnFamilyOptions {
   //
   // Default: nullptr
   std::shared_ptr<ConcurrentTaskLimiter> compaction_thread_limiter = nullptr;
+
+  // If non-nullptr, use the specified factory for a function to determine the
+  // partitioning of sst files. This helps compaction to split the files
+  // on interesting boundaries (key prefixes) to make propagation of sst
+  // files less write amplifying (covering the whole key space).
+  //
+  // Default: nullptr
+  std::shared_ptr<SstPartitionerFactory> sst_partitioner_factory = nullptr;
 
   // Create ColumnFamilyOptions with default values for all fields
   ColumnFamilyOptions();

--- a/include/rocksdb/sst_partitioner.h
+++ b/include/rocksdb/sst_partitioner.h
@@ -1,0 +1,72 @@
+// Copyright (c) 2011-present, Facebook, Inc.  All rights reserved.
+//  This source code is licensed under both the GPLv2 (found in the
+//  COPYING file in the root directory) and Apache 2.0 License
+//  (found in the LICENSE.Apache file in the root directory).
+// Copyright (c) 2012 The LevelDB Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file. See the AUTHORS file for names of contributors.
+//
+// Class for specifying user-defined functions which perform a
+// transformation on a slice.  It is not required that every slice
+// belong to the domain and/or range of a function.  Subclasses should
+// define InDomain and InRange to determine which slices are in either
+// of these sets respectively.
+
+#pragma once
+
+#include <memory>
+#include <string>
+
+namespace rocksdb {
+
+class Slice;
+
+/*
+ * A SstPartitioner is a generic pluggable way of defining the partition
+ * of SST files. Compaction job will split the SST files on partition boundary
+ * to lower the write amplification during SST file promote to higher level.
+ */
+class SstPartitioner {
+ public:
+  virtual ~SstPartitioner(){};
+
+  // Return the name of this partitioner.
+  virtual const char* Name() const = 0;
+
+  // Called with key that is right after the key that was stored into the SST
+  // Returns true of partition boundary was detected and compaction should
+  // create new file.
+  virtual bool ShouldPartition(const Slice& key) = 0;
+
+  // Called for key that was stored into the SST
+  virtual void Reset(const Slice& key) = 0;
+
+  // Context information of a compaction run
+  struct Context {
+    // Does this compaction run include all data files
+    bool is_full_compaction;
+    // Is this compaction requested by the client (true),
+    // or is it occurring as an automatic compaction process
+    bool is_manual_compaction;
+    // Output level for this compaction
+    int output_level;
+  };
+};
+
+class SstPartitionerFactory {
+ public:
+  virtual ~SstPartitionerFactory() {}
+
+  virtual std::unique_ptr<SstPartitioner> CreatePartitioner(
+      const SstPartitioner::Context& context) const = 0;
+
+  virtual SstPartitionerFactory* Clone() const = 0;
+
+  // Returns a name that identifies this partitioner factory.
+  virtual const char* Name() const = 0;
+};
+
+extern SstPartitionerFactory* NewSstPartitionerFixedPrefixFactory(
+    size_t prefix_len);
+
+}  // namespace rocksdb

--- a/java/CMakeLists.txt
+++ b/java/CMakeLists.txt
@@ -51,6 +51,12 @@ set(JNI_NATIVE_SOURCES
         rocksjni/snapshot.cc
         rocksjni/sst_file_manager.cc
         rocksjni/sst_file_writerjni.cc
+<<<<<<< HEAD
+=======
+        rocksjni/sst_file_readerjni.cc
+        rocksjni/sst_file_reader_iterator.cc
+        rocksjni/sst_partitioner.cc
+>>>>>>> d494be43d... SST Partitioner interface that allows to split SST files based on partitioning function
         rocksjni/statistics.cc
         rocksjni/statisticsjni.cc
         rocksjni/table.cc
@@ -193,7 +199,15 @@ set(JAVA_MAIN_CLASSES
   src/main/java/org/rocksdb/Snapshot.java
   src/main/java/org/rocksdb/SstFileManager.java
   src/main/java/org/rocksdb/SstFileMetaData.java
+<<<<<<< HEAD
   src/main/java/org/rocksdb/SstFileWriter.java
+=======
+  src/main/java/org/rocksdb/SstFileReader.java
+  src/main/java/org/rocksdb/SstFileReaderIterator.java
+  src/main/java/org/rocksdb/SstFileWriter.java
+  src/main/java/org/rocksdb/SstPartitionerFactory.java
+  src/main/java/org/rocksdb/SstPartitionerFixedPrefixFactory.java
+>>>>>>> d494be43d... SST Partitioner interface that allows to split SST files based on partitioning function
   src/main/java/org/rocksdb/StateType.java
   src/main/java/org/rocksdb/StatisticsCollectorCallback.java
   src/main/java/org/rocksdb/StatisticsCollector.java
@@ -436,6 +450,13 @@ if(${CMAKE_VERSION} VERSION_LESS "3.11.4" OR (${Java_VERSION_MINOR} STREQUAL "7"
           org.rocksdb.Snapshot
           org.rocksdb.SstFileManager
           org.rocksdb.SstFileWriter
+<<<<<<< HEAD
+=======
+          org.rocksdb.SstFileReader
+          org.rocksdb.SstFileReaderIterator
+          org.rocksdb.SstPartitionerFactory
+          org.rocksdb.SstPartitionerFixedPrefixFactory
+>>>>>>> d494be43d... SST Partitioner interface that allows to split SST files based on partitioning function
           org.rocksdb.Statistics
           org.rocksdb.StringAppendOperator
           org.rocksdb.TableFormatConfig

--- a/java/Makefile
+++ b/java/Makefile
@@ -60,6 +60,8 @@ NATIVE_JAVA_CLASSES = org.rocksdb.AbstractCompactionFilter\
 	org.rocksdb.Slice\
 	org.rocksdb.SstFileManager\
 	org.rocksdb.SstFileWriter\
+	org.rocksdb.SstPartitionerFactory\
+	org.rocksdb.SstPartitionerFixedPrefixFactory\
 	org.rocksdb.Statistics\
 	org.rocksdb.ThreadStatus\
 	org.rocksdb.TimedEnv\
@@ -156,6 +158,7 @@ JAVA_TESTS = org.rocksdb.BackupableDBOptionsTest\
 	org.rocksdb.SnapshotTest\
 	org.rocksdb.SstFileManagerTest\
 	org.rocksdb.SstFileWriterTest\
+	org.rocksdb.SstPartitionerTest\
 	org.rocksdb.TableFilterTest\
 	org.rocksdb.TimedEnvTest\
 	org.rocksdb.TransactionTest\

--- a/java/rocksjni/options.cc
+++ b/java/rocksjni/options.cc
@@ -5,9 +5,12 @@
 //
 // This file implements the "bridge" between Java and C++ for rocksdb::Options.
 
+#include "rocksdb/options.h"
+
 #include <jni.h>
 #include <stdio.h>
 #include <stdlib.h>
+
 #include <memory>
 #include <vector>
 
@@ -18,22 +21,20 @@
 #include "include/org_rocksdb_Options.h"
 #include "include/org_rocksdb_ReadOptions.h"
 #include "include/org_rocksdb_WriteOptions.h"
-
-#include "rocksjni/comparatorjnicallback.h"
-#include "rocksjni/portal.h"
-#include "rocksjni/statisticsjni.h"
-#include "rocksjni/table_filter_jnicallback.h"
-
 #include "rocksdb/comparator.h"
 #include "rocksdb/convenience.h"
 #include "rocksdb/db.h"
 #include "rocksdb/memtablerep.h"
 #include "rocksdb/merge_operator.h"
-#include "rocksdb/options.h"
 #include "rocksdb/rate_limiter.h"
 #include "rocksdb/slice_transform.h"
+#include "rocksdb/sst_partitioner.h"
 #include "rocksdb/statistics.h"
 #include "rocksdb/table.h"
+#include "rocksjni/comparatorjnicallback.h"
+#include "rocksjni/portal.h"
+#include "rocksjni/statisticsjni.h"
+#include "rocksjni/table_filter_jnicallback.h"
 #include "utilities/merge_operators.h"
 
 /*
@@ -1098,6 +1099,19 @@ void Java_org_rocksdb_Options_setTableFactory(
   auto* table_factory =
       reinterpret_cast<rocksdb::TableFactory*>(jtable_factory_handle);
   options->table_factory.reset(table_factory);
+}
+
+/*
+ * Method:    setSstPartitionerFactory
+ * Signature: (JJ)V
+ */
+void Java_org_rocksdb_Options_setSstPartitionerFactory(JNIEnv*, jobject,
+                                                       jlong jhandle,
+                                                       jlong factory_handle) {
+  auto* options = reinterpret_cast<ROCKSDB_NAMESPACE::Options*>(jhandle);
+  auto* factory = reinterpret_cast<ROCKSDB_NAMESPACE::SstPartitionerFactory*>(
+      factory_handle);
+  options->sst_partitioner_factory.reset(factory);
 }
 
 /*
@@ -3401,6 +3415,19 @@ void Java_org_rocksdb_ColumnFamilyOptions_setTableFactory(
     JNIEnv*, jobject, jlong jhandle, jlong jfactory_handle) {
   reinterpret_cast<rocksdb::ColumnFamilyOptions*>(jhandle)->table_factory.reset(
       reinterpret_cast<rocksdb::TableFactory*>(jfactory_handle));
+}
+
+/*
+ * Method:    setSstPartitionerFactory
+ * Signature: (JJ)V
+ */
+void Java_org_rocksdb_ColumnFamilyOptions_setSstPartitionerFactory(
+    JNIEnv*, jobject, jlong jhandle, jlong factory_handle) {
+  auto* options =
+      reinterpret_cast<ROCKSDB_NAMESPACE::ColumnFamilyOptions*>(jhandle);
+  auto* factory = reinterpret_cast<ROCKSDB_NAMESPACE::SstPartitionerFactory*>(
+      factory_handle);
+  options->sst_partitioner_factory.reset(factory);
 }
 
 /*

--- a/java/rocksjni/sst_partitioner.cc
+++ b/java/rocksjni/sst_partitioner.cc
@@ -1,0 +1,55 @@
+// Copyright (c) 2011-present, Facebook, Inc.  All rights reserved.
+//  This source code is licensed under both the GPLv2 (found in the
+//  COPYING file in the root directory) and Apache 2.0 License
+//  (found in the LICENSE.Apache file in the root directory).
+//
+// This file implements the "bridge" between Java and C++ and enables
+// calling C++ ROCKSDB_NAMESPACE::SstFileManager methods
+// from Java side.
+
+#include "rocksdb/sst_partitioner.h"
+
+#include <jni.h>
+
+#include <memory>
+
+#include "include/org_rocksdb_SstPartitionerFixedPrefixFactory.h"
+#include "rocksdb/sst_file_manager.h"
+#include "rocksjni/portal.h"
+
+/*
+ * Class:     org_rocksdb_SstPartitionerFixedPrefixFactory
+ * Method:    newSstPartitionerFixedPrefixFactory0
+ * Signature: (J)J
+ */
+jlong Java_org_rocksdb_SstPartitionerFixedPrefixFactory_newSstPartitionerFixedPrefixFactory0(
+    JNIEnv*, jclass /*jcls*/, jlong prefix_len) {
+  auto* ptr = new std::shared_ptr<ROCKSDB_NAMESPACE::SstPartitionerFactory>(
+      ROCKSDB_NAMESPACE::NewSstPartitionerFixedPrefixFactory(prefix_len));
+  return reinterpret_cast<jlong>(ptr);
+}
+
+/*
+ * Class:     org_rocksdb_SstPartitionerFixedPrefixFactory
+ * Method:    disposeInternal
+ * Signature: (J)V
+ */
+void Java_org_rocksdb_SstPartitionerFixedPrefixFactory_disposeInternal(
+    JNIEnv*, jobject /*jobj*/, jlong jhandle) {
+  auto* ptr = reinterpret_cast<
+      std::shared_ptr<ROCKSDB_NAMESPACE::SstPartitionerFactory>*>(jhandle);
+  delete ptr;  // delete std::shared_ptr
+}
+
+/*
+ * Class:     org_rocksdb_SstPartitionerFixedPrefixFactory
+ * Method:    newFactoryHandle
+ * Signature: ()J
+ */
+jlong Java_org_rocksdb_SstPartitionerFixedPrefixFactory_newFactoryHandle(
+    JNIEnv*, jobject /*jobj*/, jlong jhandle) {
+  auto* ptr = reinterpret_cast<
+      std::shared_ptr<ROCKSDB_NAMESPACE::SstPartitionerFactory>*>(jhandle);
+  auto* copy = ptr->get()->Clone();
+  return reinterpret_cast<jlong>(copy);
+}

--- a/java/src/main/java/org/rocksdb/ColumnFamilyOptions.java
+++ b/java/src/main/java/org/rocksdb/ColumnFamilyOptions.java
@@ -824,6 +824,18 @@ public class ColumnFamilyOptions extends RocksObject
     return forceConsistencyChecks(nativeHandle_);
   }
 
+  @Override
+  public ColumnFamilyOptions setSstPartitionerFactory(SstPartitionerFactory sstPartitionerFactory) {
+    setSstPartitionerFactory(nativeHandle_, sstPartitionerFactory.newFactoryHandle());
+    this.sstPartitionerFactory_ = sstPartitionerFactory;
+    return this;
+  }
+
+  @Override
+  public SstPartitionerFactory sstPartitionerFactory() {
+    return sstPartitionerFactory_;
+  }
+
   private static native long getColumnFamilyOptionsFromProps(
       String optString);
 
@@ -984,6 +996,7 @@ public class ColumnFamilyOptions extends RocksObject
   private native void setForceConsistencyChecks(final long handle,
     final boolean forceConsistencyChecks);
   private native boolean forceConsistencyChecks(final long handle);
+  private native void setSstPartitionerFactory(long nativeHandle_, long newFactoryHandle);
 
   // instance variables
   // NOTE: If you add new member variables, please update the copy constructor above!
@@ -997,5 +1010,5 @@ public class ColumnFamilyOptions extends RocksObject
   private CompactionOptionsFIFO compactionOptionsFIFO_;
   private CompressionOptions bottommostCompressionOptions_;
   private CompressionOptions compressionOptions_;
-
+  private SstPartitionerFactory sstPartitionerFactory_;
 }

--- a/java/src/main/java/org/rocksdb/ColumnFamilyOptionsInterface.java
+++ b/java/src/main/java/org/rocksdb/ColumnFamilyOptionsInterface.java
@@ -440,6 +440,23 @@ public interface ColumnFamilyOptionsInterface
   CompressionOptions compressionOptions();
 
   /**
+   * If non-nullptr, use the specified factory for a function to determine the
+   * partitioning of sst files. This helps compaction to split the files
+   * on interesting boundaries (key prefixes) to make propagation of sst
+   * files less write amplifying (covering the whole key space).
+   * @param factory The factory reference
+   * @return the reference of the current options.
+   */
+  T setSstPartitionerFactory(SstPartitionerFactory factory);
+
+  /**
+   * Get SST partitioner factory
+   *
+   * @return SST partitioner factory
+   */
+  SstPartitionerFactory sstPartitionerFactory();
+
+  /**
    * Default memtable memory budget used with the following methods:
    *
    * <ol>

--- a/java/src/main/java/org/rocksdb/Options.java
+++ b/java/src/main/java/org/rocksdb/Options.java
@@ -1735,6 +1735,18 @@ public class Options extends RocksObject
     return atomicFlush(nativeHandle_);
   }
 
+  @Override
+  public Options setSstPartitionerFactory(SstPartitionerFactory sstPartitionerFactory) {
+    setSstPartitionerFactory(nativeHandle_, sstPartitionerFactory.newFactoryHandle());
+    this.sstPartitionerFactory_ = sstPartitionerFactory;
+    return this;
+  }
+
+  @Override
+  public SstPartitionerFactory sstPartitionerFactory() {
+    return sstPartitionerFactory_;
+  }
+
   private native static long newOptions();
   private native static long newOptions(long dbOptHandle,
       long cfOptHandle);
@@ -2090,6 +2102,7 @@ public class Options extends RocksObject
   private native void setAtomicFlush(final long handle,
       final boolean atomicFlush);
   private native boolean atomicFlush(final long handle);
+  private native void setSstPartitionerFactory(long nativeHandle_, long newFactoryHandle);
 
   // instance variables
   // NOTE: If you add new member variables, please update the copy constructor above!
@@ -2108,4 +2121,5 @@ public class Options extends RocksObject
   private Cache rowCache_;
   private WalFilter walFilter_;
   private WriteBufferManager writeBufferManager_;
+  private SstPartitionerFactory sstPartitionerFactory_;
 }

--- a/java/src/main/java/org/rocksdb/SstPartitionerFactory.java
+++ b/java/src/main/java/org/rocksdb/SstPartitionerFactory.java
@@ -1,0 +1,17 @@
+// Copyright (c) 2011-present, Facebook, Inc.  All rights reserved.
+//  This source code is licensed under both the GPLv2 (found in the
+//  COPYING file in the root directory) and Apache 2.0 License
+//  (found in the LICENSE.Apache file in the root directory).
+
+package org.rocksdb;
+
+/**
+ * Handle to factory for SstPartitioner. It is used in {@link ColumnFamilyOptions}
+ */
+public abstract class SstPartitionerFactory extends RocksObject {
+  protected SstPartitionerFactory(final long nativeHandle) {
+    super(nativeHandle);
+  }
+
+  protected abstract long newFactoryHandle();
+}

--- a/java/src/main/java/org/rocksdb/SstPartitionerFixedPrefixFactory.java
+++ b/java/src/main/java/org/rocksdb/SstPartitionerFixedPrefixFactory.java
@@ -1,0 +1,26 @@
+// Copyright (c) 2011-present, Facebook, Inc.  All rights reserved.
+//  This source code is licensed under both the GPLv2 (found in the
+//  COPYING file in the root directory) and Apache 2.0 License
+//  (found in the LICENSE.Apache file in the root directory).
+
+package org.rocksdb;
+
+/**
+ * Fixed prefix factory. It partitions SST files using fixed prefix of the key.
+ */
+public class SstPartitionerFixedPrefixFactory extends SstPartitionerFactory {
+  public SstPartitionerFixedPrefixFactory(long prefixLength) {
+    super(newSstPartitionerFixedPrefixFactory0(prefixLength));
+  }
+
+  private native static long newSstPartitionerFixedPrefixFactory0(long prefixLength);
+
+  @Override protected final native void disposeInternal(final long handle);
+
+  @Override
+  protected long newFactoryHandle() {
+    return newFactoryHandle(this.nativeHandle_);
+  }
+
+  protected native long newFactoryHandle(final long handle);
+}

--- a/java/src/test/java/org/rocksdb/SstPartitionerTest.java
+++ b/java/src/test/java/org/rocksdb/SstPartitionerTest.java
@@ -1,0 +1,43 @@
+// Copyright (c) 2011-present, Facebook, Inc.  All rights reserved.
+//  This source code is licensed under both the GPLv2 (found in the
+//  COPYING file in the root directory) and Apache 2.0 License
+//  (found in the LICENSE.Apache file in the root directory).
+
+package org.rocksdb;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.List;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+public class SstPartitionerTest {
+  @ClassRule
+  public static final RocksNativeLibraryResource ROCKS_NATIVE_LIBRARY_RESOURCE =
+      new RocksNativeLibraryResource();
+
+  @Rule public TemporaryFolder dbFolder = new TemporaryFolder();
+
+  @Test
+  public void sstFixedPrefix() throws InterruptedException, RocksDBException {
+    try (final Options opt = new Options().setCreateIfMissing(true).setSstPartitionerFactory(
+             new SstPartitionerFixedPrefixFactory(4));
+
+         final RocksDB db = RocksDB.open(opt, dbFolder.getRoot().getAbsolutePath())) {
+      // writing (long)100 under key
+      db.put("aaaa1".getBytes(), "A".getBytes());
+      db.put("bbbb1".getBytes(), "B".getBytes());
+      db.flush(new FlushOptions());
+
+      db.put("aaaa1".getBytes(), "A2".getBytes());
+      db.flush(new FlushOptions());
+
+      db.compactRange();
+
+      List<LiveFileMetaData> metadata = db.getLiveFilesMetaData();
+      assertThat(metadata.size()).isEqualTo(2);
+    }
+  }
+}

--- a/options/cf_options.cc
+++ b/options/cf_options.cc
@@ -74,7 +74,7 @@ ImmutableCFOptions::ImmutableCFOptions(const ImmutableDBOptions& db_options,
           cf_options.memtable_insert_with_hint_prefix_extractor.get()),
       cf_paths(cf_options.cf_paths),
       compaction_thread_limiter(cf_options.compaction_thread_limiter),
-      sst_partitioner_factory(cf_options.sst_partitioner_factory.get()) {}
+      sst_partitioner_factory(cf_options.sst_partitioner_factory) {}
 
 // Multiple two operands. If they overflow, return op1.
 uint64_t MultiplyCheckOverflow(uint64_t op1, double op2) {

--- a/options/cf_options.cc
+++ b/options/cf_options.cc
@@ -73,7 +73,8 @@ ImmutableCFOptions::ImmutableCFOptions(const ImmutableDBOptions& db_options,
       memtable_insert_with_hint_prefix_extractor(
           cf_options.memtable_insert_with_hint_prefix_extractor.get()),
       cf_paths(cf_options.cf_paths),
-      compaction_thread_limiter(cf_options.compaction_thread_limiter) {}
+      compaction_thread_limiter(cf_options.compaction_thread_limiter),
+      sst_partitioner_factory(cf_options.sst_partitioner_factory.get()) {}
 
 // Multiple two operands. If they overflow, return op1.
 uint64_t MultiplyCheckOverflow(uint64_t op1, double op2) {

--- a/options/cf_options.h
+++ b/options/cf_options.h
@@ -123,7 +123,7 @@ struct ImmutableCFOptions {
 
   std::shared_ptr<ConcurrentTaskLimiter> compaction_thread_limiter;
 
-  const SstPartitionerFactory* sst_partitioner_factory;
+  std::shared_ptr<SstPartitionerFactory> sst_partitioner_factory;
 };
 
 struct MutableCFOptions {

--- a/options/cf_options.h
+++ b/options/cf_options.h
@@ -122,6 +122,8 @@ struct ImmutableCFOptions {
   std::vector<DbPath> cf_paths;
 
   std::shared_ptr<ConcurrentTaskLimiter> compaction_thread_limiter;
+
+  const SstPartitionerFactory* sst_partitioner_factory;
 };
 
 struct MutableCFOptions {

--- a/options/options.cc
+++ b/options/options.cc
@@ -24,6 +24,7 @@
 #include "rocksdb/slice.h"
 #include "rocksdb/slice_transform.h"
 #include "rocksdb/sst_file_manager.h"
+#include "rocksdb/sst_partitioner.h"
 #include "rocksdb/table.h"
 #include "rocksdb/table_properties.h"
 #include "rocksdb/wal_filter.h"
@@ -126,6 +127,9 @@ void ColumnFamilyOptions::Dump(Logger* log) const {
                    table_factory->Name());
   ROCKS_LOG_HEADER(log, "           table_factory options: %s",
                    table_factory->GetPrintableTableOptions().c_str());
+  ROCKS_LOG_HEADER(
+      log, " Options.sst_partitioner_factory: %s",
+      sst_partitioner_factory ? sst_partitioner_factory->Name() : "None");
   ROCKS_LOG_HEADER(log, "       Options.write_buffer_size: %" ROCKSDB_PRIszt,
                    write_buffer_size);
   ROCKS_LOG_HEADER(log, " Options.max_write_buffer_number: %d",

--- a/options/options_settable_test.cc
+++ b/options/options_settable_test.cc
@@ -358,6 +358,8 @@ TEST_F(OptionsSettableTest, ColumnFamilyOptionsAllFieldsSettable) {
        sizeof(std::vector<DbPath>)},
       {offset_of(&ColumnFamilyOptions::compaction_thread_limiter),
        sizeof(std::shared_ptr<ConcurrentTaskLimiter>)},
+      {offset_of(&ColumnFamilyOptions::sst_partitioner_factory),
+       sizeof(std::shared_ptr<SstPartitionerFactory>)},
   };
 
   char* options_ptr = new char[sizeof(ColumnFamilyOptions)];
@@ -397,6 +399,7 @@ TEST_F(OptionsSettableTest, ColumnFamilyOptionsAllFieldsSettable) {
   options->purge_redundant_kvs_while_flush = false;
   options->max_mem_compaction_level = 0;
   options->compaction_filter = nullptr;
+  options->sst_partitioner_factory = nullptr;
 
   char* new_options_ptr = new char[sizeof(ColumnFamilyOptions)];
   ColumnFamilyOptions* new_options =

--- a/src.mk
+++ b/src.mk
@@ -7,13 +7,14 @@ LIB_SOURCES =                                                   \
   db/c.cc                                                       \
   db/column_family.cc                                           \
   db/compacted_db_impl.cc                                       \
-  db/compaction/compaction.cc                                 	\
+  db/compaction/compaction.cc                                   \
   db/compaction/compaction_iterator.cc                          \
   db/compaction/compaction_job.cc                               \
   db/compaction/compaction_picker.cc                            \
   db/compaction/compaction_picker_fifo.cc                       \
   db/compaction/compaction_picker_level.cc                      \
-  db/compaction/compaction_picker_universal.cc                 	\
+  db/compaction/compaction_picker_universal.cc                  \
+  db/compaction/sst_partitioner.cc                              \
   db/convenience.cc                                             \
   db/db_filesnapshot.cc                                         \
   db/db_impl/db_impl.cc                                         \
@@ -28,7 +29,7 @@ LIB_SOURCES =                                                   \
   db/db_info_dumper.cc                                          \
   db/db_iter.cc                                                 \
   db/dbformat.cc                                                \
-  db/error_handler.cc						\
+  db/error_handler.cc                                           \
   db/event_helpers.cc                                           \
   db/experimental.cc                                            \
   db/external_sst_file_ingestion_job.cc                         \

--- a/src.mk
+++ b/src.mk
@@ -467,6 +467,7 @@ JNI_NATIVE_SOURCES =                                          \
   java/rocksjni/snapshot.cc                                   \
   java/rocksjni/sst_file_manager.cc                           \
   java/rocksjni/sst_file_writerjni.cc                         \
+  java/rocksjni/sst_partitioner.cc                            \
   java/rocksjni/statistics.cc                                 \
   java/rocksjni/statisticsjni.cc                              \
   java/rocksjni/table.cc                                      \


### PR DESCRIPTION
SST Partitioner interface that allows to split SST files during compactions.

It basically instruct compaction to create a new file when needed. When one is using well defined prefixes and prefixed way of defining tables it is good to define also partitioning so that promotion of some SST file does not cover huge key space on next level (worst case complete space).