### PR TITLE
Add Iterator and Append method for WriteBatch

### DIFF
--- a/db/write_batch.cc
+++ b/db/write_batch.cc
@@ -2037,6 +2037,7 @@ Status WriteBatchInternal::AppendContents(WriteBatch* dst,
   SetCount(dst, Count(dst) + DecodeFixed32(content.data() + 8));
   assert(content.size() >= WriteBatchInternal::kHeader);
   dst->rep_.append(content.data() + WriteBatchInternal::kHeader, src_len);
+  dst->content_flags_.store(ContentFlags::DEFERRED, std::memory_order_relaxed);
   return Status::OK();
 }
 

--- a/db/write_batch.cc
+++ b/db/write_batch.cc
@@ -2077,4 +2077,26 @@ size_t WriteBatchInternal::AppendedByteSize(size_t leftByteSize,
   }
 }
 
+void WriteBatch::Iterator::SeekToFirst() {
+  input_ = content_;
+  if (input_.size() < WriteBatchInternal::kHeader) {
+    valid_ = false;
+    return;
+  }
+  input_.remove_prefix(WriteBatchInternal::kHeader);
+  valid_ = true;
+  Next();
+}
+
+void WriteBatch::Iterator::Next() {
+  if (input_.empty() || !valid_) {
+    valid_ = false;
+    return;
+  }
+  Slice blob, xid;
+  Status s = ReadRecordFromWriteBatch(&input_, &tag_, &column_family_, &key_,
+                                      &value_, &blob, &xid);
+  valid_ = s.ok();
+}
+
 }  // namespace rocksdb

--- a/db/write_batch.cc
+++ b/db/write_batch.cc
@@ -2078,7 +2078,7 @@ size_t WriteBatchInternal::AppendedByteSize(size_t leftByteSize,
 }
 
 void WriteBatch::Iterator::SeekToFirst() {
-  input_ = content_;
+  input_ = rep_;
   if (input_.size() < WriteBatchInternal::kHeader) {
     valid_ = false;
     return;
@@ -2097,6 +2097,10 @@ void WriteBatch::Iterator::Next() {
   Status s = ReadRecordFromWriteBatch(&input_, &tag_, &column_family_, &key_,
                                       &value_, &blob, &xid);
   valid_ = s.ok();
+}
+
+int WriteBatch::WriteBatchRef::Count() const {
+  return DecodeFixed32(rep_.data() + 8);
 }
 
 }  // namespace rocksdb

--- a/db/write_batch.cc
+++ b/db/write_batch.cc
@@ -2031,6 +2031,15 @@ Status WriteBatchInternal::SetContents(WriteBatch* b, const Slice& contents) {
   return Status::OK();
 }
 
+Status WriteBatchInternal::AppendContents(WriteBatch* dst,
+                                          const Slice& content) {
+  size_t src_len = content.size() - WriteBatchInternal::kHeader;
+  SetCount(dst, Count(dst) + DecodeFixed32(content.data() + 8));
+  assert(content.size() >= WriteBatchInternal::kHeader);
+  dst->rep_.append(content.data() + WriteBatchInternal::kHeader, src_len);
+  return Status::OK();
+}
+
 Status WriteBatchInternal::Append(WriteBatch* dst, const WriteBatch* src,
                                   const bool wal_only) {
   size_t src_len;

--- a/db/write_batch_internal.h
+++ b/db/write_batch_internal.h
@@ -206,6 +206,8 @@ class WriteBatchInternal {
   static Status Append(WriteBatch* dst, const WriteBatch* src,
                        const bool WAL_only = false);
 
+  static Status AppendContents(WriteBatch* dst, const Slice& content);
+
   // Returns the byte size of appending a WriteBatch with ByteSize
   // leftByteSize and a WriteBatch with ByteSize rightByteSize
   static size_t AppendedByteSize(size_t leftByteSize, size_t rightByteSize);

--- a/include/rocksdb/write_batch.h
+++ b/include/rocksdb/write_batch.h
@@ -277,7 +277,7 @@ class WriteBatch : public WriteBatchBase {
   };
   Status Iterate(Handler* handler) const;
   class Iterator;
-  Iterator* NewIterator() const { return new Iterator(this); }
+  Iterator* NewIterator() const { return new Iterator(rep_); }
 
   // Retrieve the serialized version of this batch.
   const std::string& Data() const { return rep_; }
@@ -377,7 +377,7 @@ class WriteBatch : public WriteBatchBase {
  public:
   class Iterator {
    private:
-    Slice content_;
+    const Slice& rep_;
     Slice input_;
     Slice key_;
     Slice value_;
@@ -386,8 +386,7 @@ class WriteBatch : public WriteBatchBase {
     bool valid_;
 
    public:
-    explicit Iterator(const WriteBatch* wb)
-        : content_(wb->rep_), valid_(false) {}
+    explicit Iterator(const Slice& rep) : rep_(rep), valid_(false) {}
 
     bool Valid() const { return valid_; }
 
@@ -402,6 +401,16 @@ class WriteBatch : public WriteBatchBase {
     void SeekToFirst();
 
     void Next();
+  };
+  class WriteBatchRef {
+   public:
+    explicit WriteBatchRef(const Slice& rep) : rep_(rep) {}
+    Iterator* NewIterator() const { return new Iterator(rep_); }
+
+    int Count() const;
+
+   private:
+    const Slice& rep_;
   };
 };
 

--- a/include/rocksdb/write_batch.h
+++ b/include/rocksdb/write_batch.h
@@ -277,8 +277,8 @@ class WriteBatch : public WriteBatchBase {
   };
   Status Iterate(Handler* handler) const;
   class Iterator;
-  Iterator* NewIterator() const {
-    return new Iterator(this);
+  Iterator NewIterator() const {
+    return Iterator(this);
   }
 
   // Retrieve the serialized version of this batch.

--- a/include/rocksdb/write_batch.h
+++ b/include/rocksdb/write_batch.h
@@ -277,7 +277,7 @@ class WriteBatch : public WriteBatchBase {
   };
   Status Iterate(Handler* handler) const;
   class Iterator;
-  Iterator NewIterator() const { return Iterator(this); }
+  Iterator* NewIterator() const { return new Iterator(this); }
 
   // Retrieve the serialized version of this batch.
   const std::string& Data() const { return rep_; }

--- a/include/rocksdb/write_batch.h
+++ b/include/rocksdb/write_batch.h
@@ -377,7 +377,7 @@ class WriteBatch : public WriteBatchBase {
  public:
   class Iterator {
    private:
-    const Slice& rep_;
+    Slice rep_;
     Slice input_;
     Slice key_;
     Slice value_;

--- a/include/rocksdb/write_batch.h
+++ b/include/rocksdb/write_batch.h
@@ -276,6 +276,10 @@ class WriteBatch : public WriteBatchBase {
     virtual bool WriteBeforePrepare() const { return false; }
   };
   Status Iterate(Handler* handler) const;
+  class Iterator;
+  Iterator* NewIterator() const {
+    return new Iterator(this);
+  }
 
   // Retrieve the serialized version of this batch.
   const std::string& Data() const { return rep_; }
@@ -372,6 +376,28 @@ class WriteBatch : public WriteBatchBase {
   const size_t timestamp_size_;
 
   // Intentionally copyable
+ public:
+  class Iterator {
+   private:
+    Slice content_;
+    Slice input_;
+
+   public:
+    Slice key_;
+    Slice value_;
+    uint32_t column_family_;
+    char tag_;
+    bool valid_;
+
+    explicit Iterator(const WriteBatch* wb)
+        : content_(wb->rep_), valid_(false) {}
+
+    bool Valid() const { return valid_; }
+
+    void SeekToFirst();
+
+    void Next();
+  };
 };
 
 }  // namespace rocksdb

--- a/include/rocksdb/write_batch.h
+++ b/include/rocksdb/write_batch.h
@@ -277,9 +277,7 @@ class WriteBatch : public WriteBatchBase {
   };
   Status Iterate(Handler* handler) const;
   class Iterator;
-  Iterator NewIterator() const {
-    return Iterator(this);
-  }
+  Iterator NewIterator() const { return Iterator(this); }
 
   // Retrieve the serialized version of this batch.
   const std::string& Data() const { return rep_; }
@@ -381,18 +379,25 @@ class WriteBatch : public WriteBatchBase {
    private:
     Slice content_;
     Slice input_;
-
-   public:
     Slice key_;
     Slice value_;
     uint32_t column_family_;
     char tag_;
     bool valid_;
 
+   public:
     explicit Iterator(const WriteBatch* wb)
         : content_(wb->rep_), valid_(false) {}
 
     bool Valid() const { return valid_; }
+
+    Slice Key() const { return key_; }
+
+    Slice Value() const { return value_; }
+
+    uint32_t GetColumnFamilyId() const { return column_family_; }
+
+    char GetValueType() const { return tag_; };
 
     void SeekToFirst();
 


### PR DESCRIPTION
I want to use format of rocksdb::WriteBatch to encode key-value pairs of TiKV, and I need an more effective method to copy data from Entry to WriteBatch directly so that I could avoid CPU cost of decode.