### PR TITLE
Code changes to plugin rocksdb_cloud

### DIFF
--- a/db/version_set.h
+++ b/db/version_set.h
@@ -1019,19 +1019,19 @@ class VersionSet {
 
   static uint64_t GetTotalSstFilesSize(Version* dummy_versions);
 
+  struct LogReporter : public log::Reader::Reporter {
+     Status* status;
+     virtual void Corruption(size_t /*bytes*/, const Status& s) override {
+       if (this->status->ok()) *this->status = s;
+     }
+   };
+
  protected:
   struct ManifestWriter;
 
   friend class Version;
   friend class DBImpl;
   friend class DBImplReadOnly;
-
-  struct LogReporter : public log::Reader::Reporter {
-    Status* status;
-    virtual void Corruption(size_t /*bytes*/, const Status& s) override {
-      if (this->status->ok()) *this->status = s;
-    }
-  };
 
   // ApproximateSize helper
   uint64_t ApproximateSizeLevel0(Version* v, const LevelFilesBrief& files_brief,


### PR DESCRIPTION
Related to tikv/rust-rocksdb#517 and tikv/rocksdb#182
### Summary
Adds code used in compiling with [rocksdb~6.4.tikv](https://github.com/tikv/rocksdb/tree/6.4.tikv) along with [rocksdb~6.4.cloud](https://github.com/tikv/rocksdb/tree/6.4.cloud)

### Changes
- Makes public the struct LogReporter so that it can be accessed by [rocksdb~6.4.cloud/cloud/manifest_reader.cc#L114](https://github.com/tikv/rocksdb/blob/6a7c514453e3e3e1c3bb57c18d8e0280089ccdcd/cloud/manifest_reader.cc#L114)

Signed-off-by: Devdutt Shenoi <devdutt@outlook.in>