### PR TITLE
Ignore ingest files for dynamic level bytes

### DIFF
--- a/db/compaction/compaction_picker_level.cc
+++ b/db/compaction/compaction_picker_level.cc
@@ -482,6 +482,11 @@ bool LevelCompactionBuilder::PickFileToCompact() {
     int index = file_size[cmp_idx];
     auto* f = level_files[index];
 
+    // TODO: if (mutable_cf_options.ingest_tolerant_ratio != 0 && CanIgnoreFile(f, level)) continue;
+    if (vstorage_->CanIgnoreFile(f, start_level_)) {
+      continue;
+    }
+
     // do not pick a file to compact if it is being compacted
     // from n-1 level.
     if (f->being_compacted) {

--- a/db/compaction/compaction_picker_test.cc
+++ b/db/compaction/compaction_picker_test.cc
@@ -71,8 +71,9 @@ class CompactionPickerTest : public testing::Test {
   void NewVersionStorage(int num_levels, CompactionStyle style) {
     DeleteVersionStorage();
     options_.num_levels = num_levels;
-    vstorage_.reset(new VersionStorageInfo(&icmp_, ucmp_, options_.num_levels,
-                                           style, nullptr, false));
+    vstorage_.reset(new VersionStorageInfo(
+        &icmp_, ucmp_, options_.num_levels, style, nullptr, false,
+        options_.level_compaction_dynamic_level_bytes));
     vstorage_->CalculateBaseBytes(ioptions_, mutable_cf_options_);
   }
 
@@ -85,7 +86,7 @@ class CompactionPickerTest : public testing::Test {
 
   void Add(int level, uint32_t file_number, const char* smallest,
            const char* largest, uint64_t file_size = 1, uint32_t path_id = 0,
-           SequenceNumber smallest_seq = 100, SequenceNumber largest_seq = 100,
+           SequenceNumber smallest_seq = 100, SequenceNumber largest_seq = 101,
            size_t compensated_file_size = 0) {
     assert(level < vstorage_->num_levels());
     FileMetaData* f = new FileMetaData;
@@ -120,9 +121,9 @@ class CompactionPickerTest : public testing::Test {
   }
 
   void UpdateVersionStorageInfo() {
-    vstorage_->CalculateBaseBytes(ioptions_, mutable_cf_options_);
     vstorage_->UpdateFilesByCompactionPri(ioptions_.compaction_pri);
     vstorage_->UpdateNumNonEmptyLevels();
+    vstorage_->CalculateBaseBytes(ioptions_, mutable_cf_options_);
     vstorage_->GenerateFileIndexer();
     vstorage_->GenerateLevelFilesBrief(mutable_cf_options_);
     vstorage_->ComputeCompactionScore(ioptions_, mutable_cf_options_);

--- a/db/compaction/compaction_picker_test.cc
+++ b/db/compaction/compaction_picker_test.cc
@@ -124,7 +124,7 @@ class CompactionPickerTest : public testing::Test {
     vstorage_->UpdateFilesByCompactionPri(ioptions_.compaction_pri);
     vstorage_->UpdateNumNonEmptyLevels();
     vstorage_->GenerateFileIndexer();
-    vstorage_->GenerateLevelFilesBrief();
+    vstorage_->GenerateLevelFilesBrief(mutable_cf_options_);
     vstorage_->ComputeCompactionScore(ioptions_, mutable_cf_options_);
     vstorage_->GenerateLevel0NonOverlapping();
     vstorage_->ComputeFilesMarkedForCompaction();

--- a/db/compaction/compaction_picker_test.cc
+++ b/db/compaction/compaction_picker_test.cc
@@ -73,7 +73,7 @@ class CompactionPickerTest : public testing::Test {
     options_.num_levels = num_levels;
     vstorage_.reset(new VersionStorageInfo(
         &icmp_, ucmp_, options_.num_levels, style, nullptr, false,
-        options_.level_compaction_dynamic_level_bytes));
+        ioptions_.level_compaction_dynamic_level_bytes));
     vstorage_->CalculateBaseBytes(ioptions_, mutable_cf_options_);
   }
 

--- a/db/db_impl/db_impl.cc
+++ b/db/db_impl/db_impl.cc
@@ -4136,6 +4136,7 @@ void DBImpl::NotifyOnExternalFileIngested(
     info.internal_file_path = f.internal_file_path;
     info.global_seqno = f.assigned_seqno;
     info.table_properties = f.table_properties;
+    info.picked_level = f.picked_level;
     for (auto listener : immutable_db_options_.listeners) {
       listener->OnExternalFileIngested(this, info);
     }

--- a/db/db_test.cc
+++ b/db/db_test.cc
@@ -4632,6 +4632,10 @@ TEST_F(DBTest, DynamicCompactionOptions) {
   }
   dbfull()->TEST_WaitForCompact();
   ASSERT_LT(NumTableFilesAtLevel(0), 4);
+
+  ASSERT_EQ(dbfull()->GetOptions().ingest_tolerant_ratio, 0);
+  ASSERT_OK(dbfull()->SetOptions({{"ingest_tolerant_ratio", "10"}}));
+  ASSERT_EQ(dbfull()->GetOptions().ingest_tolerant_ratio, 10);
 }
 
 // Test dynamic FIFO compaction options.

--- a/db/external_sst_file_ingestion_job.cc
+++ b/db/external_sst_file_ingestion_job.cc
@@ -550,11 +550,11 @@ Status ExternalSstFileIngestionJob::AssignLevelAndSeqnoForIngestedFile(
     if (vstorage->MaxStaticBytesForLevel(target_level) <=
             file_to_ingest->file_size + vstorage->NumLevelBytes(target_level) ||
         !IngestedFileFitInLevel(file_to_ingest, target_level)) {
-      ROCKS_LOG_INFO(db_options_.info_log,
-                     "ingest bytes %lu %lu exceed level size %lu for level %d",
-                     file_to_ingest->file_size,
-                     vstorage->NumLevelBytes(target_level),
-                     vstorage->MaxBytesForLevel(target_level), target_level);
+      ROCKS_LOG_INFO(
+          db_options_.info_log, "ingest bytes %" PRIu64 " + %" PRIu64
+                                " exceed level size %" PRIu64 " for level %d",
+          file_to_ingest->file_size, vstorage->NumLevelBytes(target_level),
+          vstorage->MaxBytesForLevel(target_level), target_level);
       target_level--;
     } else {
       break;

--- a/db/external_sst_file_ingestion_job.cc
+++ b/db/external_sst_file_ingestion_job.cc
@@ -538,10 +538,6 @@ Status ExternalSstFileIngestionJob::AssignLevelAndSeqnoForIngestedFile(
     // if our file can fit in it
     if (IngestedFileFitInLevel(file_to_ingest, lvl)) {
       target_level = lvl;
-    } else if (lvl == cfd_->NumberLevels() - 1) {
-      ROCKS_LOG_INFO(db_options_.info_log,
-                     "can't ingest into bottom level due to range overlap %d",
-                     cfd_->NumberLevels() - 1);
     }
   }
   TEST_SYNC_POINT_CALLBACK(
@@ -644,14 +640,12 @@ bool ExternalSstFileIngestionJob::IngestedFileFitInLevel(
                                &file_largest_user_key)) {
     // File overlap with another files in this level, we cannot
     // add it to this level
-    ROCKS_LOG_INFO(db_options_.info_log, "range overlap in L%d", level);
     return false;
   }
   if (cfd_->RangeOverlapWithCompaction(file_smallest_user_key,
                                        file_largest_user_key, level)) {
     // File overlap with a running compaction output that will be stored
     // in this level, we cannot add this file to this level
-    ROCKS_LOG_INFO(db_options_.info_log, "compaction overlap in L%d", level);
     return false;
   }
 

--- a/db/external_sst_file_ingestion_job.cc
+++ b/db/external_sst_file_ingestion_job.cc
@@ -240,7 +240,7 @@ Status ExternalSstFileIngestionJob::Run() {
     edit_.AddFile(f.picked_level, f.fd.GetNumber(), f.fd.GetPathId(),
                   f.fd.GetFileSize(), f.smallest_internal_key(),
                   f.largest_internal_key(), f.assigned_seqno, f.assigned_seqno,
-                  false, true);
+                  false);
   }
   return status;
 }

--- a/db/external_sst_file_ingestion_job.cc
+++ b/db/external_sst_file_ingestion_job.cc
@@ -544,32 +544,6 @@ Status ExternalSstFileIngestionJob::AssignLevelAndSeqnoForIngestedFile(
                      cfd_->NumberLevels() - 1);
     }
   }
-
-  auto origin_target_level = target_level;
-  while (target_level >= vstorage->base_level()) {
-    if (vstorage->MaxStaticBytesForLevel(target_level) <=
-            file_to_ingest->file_size + vstorage->NumLevelBytes(target_level) ||
-        !IngestedFileFitInLevel(file_to_ingest, target_level)) {
-      ROCKS_LOG_INFO(
-          db_options_.info_log, "ingest bytes %" PRIu64 " + %" PRIu64
-                                " exceed level size %" PRIu64 " for level %d",
-          file_to_ingest->file_size, vstorage->NumLevelBytes(target_level),
-          vstorage->MaxBytesForLevel(target_level), target_level);
-      target_level--;
-    } else {
-      break;
-    }
-  }
-
-  if (target_level == 0) {
-    target_level = origin_target_level;
-    ROCKS_LOG_INFO(db_options_.info_log, "ingest to origin level %d",
-                   origin_target_level);
-  } else if (target_level < vstorage->base_level()) {
-    target_level = 0;
-    ROCKS_LOG_INFO(db_options_.info_log, "ingest before base level %d",
-                   vstorage->base_level());
-  }
   TEST_SYNC_POINT_CALLBACK(
       "ExternalSstFileIngestionJob::AssignLevelAndSeqnoForIngestedFile",
       &overlap_with_db);

--- a/db/internal_stats.cc
+++ b/db/internal_stats.cc
@@ -569,8 +569,8 @@ bool InternalStats::HandleNumIngestedFilesAtLevel(std::string* value,
     return false;
   } else {
     char buf[100];
-    snprintf(buf, sizeof(buf), "%d",
-             vstorage->GetNumLevelIngestedFiles(static_cast<int>(level)));
+    snprintf(buf, sizeof(buf), "%" ROCKSDB_PRIszt,
+             vstorage->LevelFilesBrief(static_cast<int>(level)).num_ingested_files);
     *value = buf;
     return true;
   }
@@ -586,7 +586,7 @@ bool InternalStats::HandleNumIngestedBytesAtLevel(std::string* value,
   } else {
     char buf[100];
     snprintf(buf, sizeof(buf), "%" PRIu64,
-             vstorage->GetNumLevelIngestedBytes(static_cast<int>(level)));
+             vstorage->LevelFilesBrief(static_cast<int>(level)).num_ingested_bytes);
     *value = buf;
     return true;
   }

--- a/db/internal_stats.cc
+++ b/db/internal_stats.cc
@@ -576,8 +576,9 @@ bool InternalStats::HandleNumIngestedFilesAtLevel(std::string* value,
     return false;
   } else {
     char buf[100];
-    snprintf(buf, sizeof(buf), "%" ROCKSDB_PRIszt,
-             vstorage->LevelFilesBrief(static_cast<int>(level)).num_ingested_files);
+    snprintf(
+        buf, sizeof(buf), "%" ROCKSDB_PRIszt,
+        vstorage->LevelFilesBrief(static_cast<int>(level)).num_ingested_files);
     *value = buf;
     return true;
   }
@@ -592,8 +593,9 @@ bool InternalStats::HandleNumIngestedBytesAtLevel(std::string* value,
     return false;
   } else {
     char buf[100];
-    snprintf(buf, sizeof(buf), "%" PRIu64,
-             vstorage->LevelFilesBrief(static_cast<int>(level)).num_ingested_bytes);
+    snprintf(
+        buf, sizeof(buf), "%" PRIu64,
+        vstorage->LevelFilesBrief(static_cast<int>(level)).num_ingested_bytes);
     *value = buf;
     return true;
   }
@@ -608,8 +610,9 @@ bool InternalStats::HandleNumTolerantBytesAtLevel(std::string* value,
     return false;
   } else {
     char buf[100];
-    snprintf(buf, sizeof(buf), "%" PRIu64,
-             vstorage->LevelFilesBrief(static_cast<int>(level)).num_tolerant_bytes);
+    snprintf(
+        buf, sizeof(buf), "%" PRIu64,
+        vstorage->LevelFilesBrief(static_cast<int>(level)).num_tolerant_bytes);
     *value = buf;
     return true;
   }

--- a/db/internal_stats.cc
+++ b/db/internal_stats.cc
@@ -372,7 +372,7 @@ const std::unordered_map<std::string, DBPropertyInfo>
          {false, &InternalStats::HandleNumIngestedBytesAtLevel, nullptr,
           nullptr, nullptr}},
         {DB::Properties::kNumTolerantBytesAtLevelPrefix,
-         {false, &InternalStats::HandleTolerantBytesAtLevel, nullptr,
+         {false, &InternalStats::HandleNumTolerantBytesAtLevel, nullptr,
           nullptr, nullptr}},
         {DB::Properties::kCompressionRatioAtLevelPrefix,
          {false, &InternalStats::HandleCompressionRatioAtLevelPrefix, nullptr,
@@ -599,7 +599,7 @@ bool InternalStats::HandleNumIngestedBytesAtLevel(std::string* value,
   }
 }
 
-bool InternalStats::HandleTolerantBytesAtLevel(std::string* value,
+bool InternalStats::HandleNumTolerantBytesAtLevel(std::string* value,
                                                   Slice suffix) {
   uint64_t level;
   const auto* vstorage = cfd_->current()->storage_info();
@@ -609,7 +609,7 @@ bool InternalStats::HandleTolerantBytesAtLevel(std::string* value,
   } else {
     char buf[100];
     snprintf(buf, sizeof(buf), "%" PRIu64,
-             vstorage->LevelFilesBrief(static_cast<int>(level)).tolerant_bytes);
+             vstorage->LevelFilesBrief(static_cast<int>(level)).num_tolerant_bytes);
     *value = buf;
     return true;
   }

--- a/db/internal_stats.h
+++ b/db/internal_stats.h
@@ -516,6 +516,8 @@ class InternalStats {
   // Handler functions for getting property values. They use "value" as a value-
   // result argument, and return true upon successfully setting "value".
   bool HandleNumFilesAtLevel(std::string* value, Slice suffix);
+  bool HandleNumIngestedFilesAtLevel(std::string* value, Slice suffix);
+  bool HandleNumIngestedBytesAtLevel(std::string* value, Slice suffix);
   bool HandleCompressionRatioAtLevelPrefix(std::string* value, Slice suffix);
   bool HandleLevelStats(std::string* value, Slice suffix);
   bool HandleStats(std::string* value, Slice suffix);

--- a/db/internal_stats.h
+++ b/db/internal_stats.h
@@ -516,6 +516,7 @@ class InternalStats {
   // Handler functions for getting property values. They use "value" as a value-
   // result argument, and return true upon successfully setting "value".
   bool HandleNumFilesAtLevel(std::string* value, Slice suffix);
+  bool HandleNumMaxBytesAtLevel(std::string* value, Slice suffix);
   bool HandleNumIngestedFilesAtLevel(std::string* value, Slice suffix);
   bool HandleNumIngestedBytesAtLevel(std::string* value, Slice suffix);
   bool HandleNumTolerantBytesAtLevel(std::string* value, Slice suffix);

--- a/db/internal_stats.h
+++ b/db/internal_stats.h
@@ -518,6 +518,7 @@ class InternalStats {
   bool HandleNumFilesAtLevel(std::string* value, Slice suffix);
   bool HandleNumIngestedFilesAtLevel(std::string* value, Slice suffix);
   bool HandleNumIngestedBytesAtLevel(std::string* value, Slice suffix);
+  bool HandleTolerantBytesAtLevel(std::string* value, Slice suffix);
   bool HandleCompressionRatioAtLevelPrefix(std::string* value, Slice suffix);
   bool HandleLevelStats(std::string* value, Slice suffix);
   bool HandleStats(std::string* value, Slice suffix);

--- a/db/internal_stats.h
+++ b/db/internal_stats.h
@@ -518,7 +518,7 @@ class InternalStats {
   bool HandleNumFilesAtLevel(std::string* value, Slice suffix);
   bool HandleNumIngestedFilesAtLevel(std::string* value, Slice suffix);
   bool HandleNumIngestedBytesAtLevel(std::string* value, Slice suffix);
-  bool HandleTolerantBytesAtLevel(std::string* value, Slice suffix);
+  bool HandleNumTolerantBytesAtLevel(std::string* value, Slice suffix);
   bool HandleCompressionRatioAtLevelPrefix(std::string* value, Slice suffix);
   bool HandleLevelStats(std::string* value, Slice suffix);
   bool HandleStats(std::string* value, Slice suffix);

--- a/db/version_builder_test.cc
+++ b/db/version_builder_test.cc
@@ -80,7 +80,7 @@ class VersionBuilderTest : public testing::Test {
     vstorage_.UpdateFilesByCompactionPri(ioptions_.compaction_pri);
     vstorage_.UpdateNumNonEmptyLevels();
     vstorage_.GenerateFileIndexer();
-    vstorage_.GenerateLevelFilesBrief();
+    vstorage_.GenerateLevelFilesBrief(mutable_cf_options_);
     vstorage_.CalculateBaseBytes(ioptions_, mutable_cf_options_);
     vstorage_.GenerateLevel0NonOverlapping();
     vstorage_.SetFinalized();

--- a/db/version_edit.cc
+++ b/db/version_edit.cc
@@ -55,7 +55,6 @@ enum CustomTag : uint32_t {
   // kMinLogNumberToKeep as part of a CustomTag as a hack. This should be
   // removed when manifest becomes forward-comptabile.
   kMinLogNumberToKeepHack = 3,
-  kIngestFile = 4,
   kPathId = 65,
 };
 // If this bit for the custom tag is set, opening DB should fail if
@@ -125,8 +124,7 @@ bool VersionEdit::EncodeTo(std::string* dst) const {
       return false;
     }
     bool has_customized_fields = false;
-    if (f.marked_for_compaction || has_min_log_number_to_keep_ ||
-        f.ingested_file) {
+    if (f.marked_for_compaction || has_min_log_number_to_keep_) {
       PutVarint32(dst, kNewFile4);
       has_customized_fields = true;
     } else if (f.fd.GetPathId() == 0) {
@@ -171,9 +169,7 @@ bool VersionEdit::EncodeTo(std::string* dst) const {
       //   tag kPathId: 1 byte as path_id
       //   tag kNeedCompaction:
       //        now only can take one char value 1 indicating need-compaction
-      //   tag kIngestFile:
-      //        now only can take one char value 1 indicating it is a ingested
-      //        file
+      //
       if (f.fd.GetPathId() != 0) {
         PutVarint32(dst, CustomTag::kPathId);
         char p = static_cast<char>(f.fd.GetPathId());
@@ -190,11 +186,6 @@ bool VersionEdit::EncodeTo(std::string* dst) const {
         PutFixed64(&varint_log_number, min_log_number_to_keep_);
         PutLengthPrefixedSlice(dst, Slice(varint_log_number));
         min_log_num_written = true;
-      }
-      if (f.ingested_file) {
-        PutVarint32(dst, CustomTag::kIngestFile);
-        char p = static_cast<char>(1);
-        PutLengthPrefixedSlice(dst, Slice(&p, 1));
       }
       TEST_SYNC_POINT_CALLBACK("VersionEdit::EncodeTo:NewFile4:CustomizeFields",
                                dst);
@@ -300,12 +291,6 @@ const char* VersionEdit::DecodeNewFile4From(Slice* input) {
             return "deleted log number malformatted";
           }
           has_min_log_number_to_keep_ = true;
-          break;
-        case kIngestFile:
-          if (field.size() != 1) {
-            return "ingest file field wrong size";
-          }
-          f.ingested_file = (field[0] == 1);
           break;
         default:
           if ((custom_tag & kCustomTagNonSafeIgnoreMask) != 0) {

--- a/db/version_edit.cc
+++ b/db/version_edit.cc
@@ -55,6 +55,7 @@ enum CustomTag : uint32_t {
   // kMinLogNumberToKeep as part of a CustomTag as a hack. This should be
   // removed when manifest becomes forward-comptabile.
   kMinLogNumberToKeepHack = 3,
+  kIngestFile = 4,
   kPathId = 65,
 };
 // If this bit for the custom tag is set, opening DB should fail if
@@ -124,7 +125,8 @@ bool VersionEdit::EncodeTo(std::string* dst) const {
       return false;
     }
     bool has_customized_fields = false;
-    if (f.marked_for_compaction || has_min_log_number_to_keep_) {
+    if (f.marked_for_compaction || has_min_log_number_to_keep_ ||
+        f.ingested_file) {
       PutVarint32(dst, kNewFile4);
       has_customized_fields = true;
     } else if (f.fd.GetPathId() == 0) {
@@ -169,7 +171,9 @@ bool VersionEdit::EncodeTo(std::string* dst) const {
       //   tag kPathId: 1 byte as path_id
       //   tag kNeedCompaction:
       //        now only can take one char value 1 indicating need-compaction
-      //
+      //   tag kIngestFile:
+      //        now only can take one char value 1 indicating it is a ingested
+      //        file
       if (f.fd.GetPathId() != 0) {
         PutVarint32(dst, CustomTag::kPathId);
         char p = static_cast<char>(f.fd.GetPathId());
@@ -186,6 +190,11 @@ bool VersionEdit::EncodeTo(std::string* dst) const {
         PutFixed64(&varint_log_number, min_log_number_to_keep_);
         PutLengthPrefixedSlice(dst, Slice(varint_log_number));
         min_log_num_written = true;
+      }
+      if (f.ingested_file) {
+        PutVarint32(dst, CustomTag::kIngestFile);
+        char p = static_cast<char>(1);
+        PutLengthPrefixedSlice(dst, Slice(&p, 1));
       }
       TEST_SYNC_POINT_CALLBACK("VersionEdit::EncodeTo:NewFile4:CustomizeFields",
                                dst);
@@ -291,6 +300,12 @@ const char* VersionEdit::DecodeNewFile4From(Slice* input) {
             return "deleted log number malformatted";
           }
           has_min_log_number_to_keep_ = true;
+          break;
+        case kIngestFile:
+          if (field.size() != 1) {
+            return "ingest file field wrong size";
+          }
+          f.ingested_file = (field[0] == 1);
           break;
         default:
           if ((custom_tag & kCustomTagNonSafeIgnoreMask) != 0) {

--- a/db/version_edit.h
+++ b/db/version_edit.h
@@ -186,6 +186,7 @@ struct LevelFilesBrief {
   size_t num_files;
   size_t num_ingested_files;
   uint64_t num_ingested_bytes;
+  uint64_t tolerant_bytes;
   FdWithKeyRange* files;
   LevelFilesBrief() {
     num_files = 0;

--- a/db/version_edit.h
+++ b/db/version_edit.h
@@ -184,6 +184,8 @@ struct FdWithKeyRange {
 // Actual data is guaranteed to be stored closely
 struct LevelFilesBrief {
   size_t num_files;
+  size_t num_ingested_files;
+  uint64_t num_ingested_bytes;
   FdWithKeyRange* files;
   LevelFilesBrief() {
     num_files = 0;

--- a/db/version_edit.h
+++ b/db/version_edit.h
@@ -186,7 +186,7 @@ struct LevelFilesBrief {
   size_t num_files;
   size_t num_ingested_files;
   uint64_t num_ingested_bytes;
-  uint64_t tolerant_bytes;
+  uint64_t num_tolerant_bytes;
   FdWithKeyRange* files;
   LevelFilesBrief() {
     num_files = 0;

--- a/db/version_edit.h
+++ b/db/version_edit.h
@@ -116,6 +116,7 @@ struct FileMetaData {
 
   bool marked_for_compaction;  // True if client asked us nicely to compact this
                                // file.
+  bool ingested_file;          // True if the file is ingested externally.
 
   FileMetaData()
       : table_reader_handle(nullptr),
@@ -127,7 +128,8 @@ struct FileMetaData {
         refs(0),
         being_compacted(false),
         init_stats_from_file(false),
-        marked_for_compaction(false) {}
+        marked_for_compaction(false),
+        ingested_file(false) {}
 
   // REQUIRED: Keys must be given to the function in sorted order (it expects
   // the last key to be the largest).
@@ -241,8 +243,8 @@ class VersionEdit {
   void AddFile(int level, uint64_t file, uint32_t file_path_id,
                uint64_t file_size, const InternalKey& smallest,
                const InternalKey& largest, const SequenceNumber& smallest_seqno,
-               const SequenceNumber& largest_seqno,
-               bool marked_for_compaction) {
+               const SequenceNumber& largest_seqno, bool marked_for_compaction,
+               bool ingest = false) {
     assert(smallest_seqno <= largest_seqno);
     FileMetaData f;
     f.fd = FileDescriptor(file, file_path_id, file_size, smallest_seqno,
@@ -252,6 +254,7 @@ class VersionEdit {
     f.fd.smallest_seqno = smallest_seqno;
     f.fd.largest_seqno = largest_seqno;
     f.marked_for_compaction = marked_for_compaction;
+    f.ingested_file = ingest;
     new_files_.emplace_back(level, std::move(f));
   }
 

--- a/db/version_edit.h
+++ b/db/version_edit.h
@@ -190,6 +190,9 @@ struct LevelFilesBrief {
   FdWithKeyRange* files;
   LevelFilesBrief() {
     num_files = 0;
+    num_ingested_files = 0;
+    num_ingested_bytes = 0;
+    num_tolerant_bytes = 0;
     files = nullptr;
   }
 };

--- a/db/version_edit.h
+++ b/db/version_edit.h
@@ -116,7 +116,6 @@ struct FileMetaData {
 
   bool marked_for_compaction;  // True if client asked us nicely to compact this
                                // file.
-  bool ingested_file;          // True if the file is ingested externally.
 
   FileMetaData()
       : table_reader_handle(nullptr),
@@ -128,8 +127,7 @@ struct FileMetaData {
         refs(0),
         being_compacted(false),
         init_stats_from_file(false),
-        marked_for_compaction(false),
-        ingested_file(false) {}
+        marked_for_compaction(false) {}
 
   // REQUIRED: Keys must be given to the function in sorted order (it expects
   // the last key to be the largest).
@@ -243,8 +241,8 @@ class VersionEdit {
   void AddFile(int level, uint64_t file, uint32_t file_path_id,
                uint64_t file_size, const InternalKey& smallest,
                const InternalKey& largest, const SequenceNumber& smallest_seqno,
-               const SequenceNumber& largest_seqno, bool marked_for_compaction,
-               bool ingest = false) {
+               const SequenceNumber& largest_seqno,
+               bool marked_for_compaction) {
     assert(smallest_seqno <= largest_seqno);
     FileMetaData f;
     f.fd = FileDescriptor(file, file_path_id, file_size, smallest_seqno,
@@ -254,7 +252,6 @@ class VersionEdit {
     f.fd.smallest_seqno = smallest_seqno;
     f.fd.largest_seqno = largest_seqno;
     f.marked_for_compaction = marked_for_compaction;
-    f.ingested_file = ingest;
     new_files_.emplace_back(level, std::move(f));
   }
 

--- a/db/version_set.cc
+++ b/db/version_set.cc
@@ -1984,7 +1984,7 @@ bool Version::IsFilterSkipped(int level, bool is_file_last_in_level) {
          level == storage_info_.num_non_empty_levels() - 1;
 }
 
-void VersionStorageInfo::GenerateLevelFilesBrief() {
+void VersionStorageInfo::GenerateLevelFilesBrief(const MutableCFOptions& options) {
   level_files_brief_.resize(num_non_empty_levels_);
   for (int level = 0; level < num_non_empty_levels_; level++) {
     DoGenerateLevelFilesBrief(
@@ -1993,6 +1993,7 @@ void VersionStorageInfo::GenerateLevelFilesBrief() {
       if (LikelyIngestedFile(f, level)) {
         level_files_brief_[level].num_ingested_files += 1;
         level_files_brief_[level].num_ingested_bytes += f->fd.GetFileSize();
+        level_files_brief_[level].tolerant_bytes += static_cast<double>(options.ingest_tolerant_ratio) / (level - base_level_ + 1) * MaxBytesForLevel(level);
       }
     }
   }
@@ -2006,7 +2007,7 @@ void Version::PrepareApply(
   storage_info_.CalculateBaseBytes(*cfd_->ioptions(), mutable_cf_options);
   storage_info_.UpdateFilesByCompactionPri(cfd_->ioptions()->compaction_pri);
   storage_info_.GenerateFileIndexer();
-  storage_info_.GenerateLevelFilesBrief();
+  storage_info_.GenerateLevelFilesBrief(mutable_cf_options);
   storage_info_.GenerateLevel0NonOverlapping();
   storage_info_.GenerateBottommostFiles();
 }

--- a/db/version_set.cc
+++ b/db/version_set.cc
@@ -1994,8 +1994,10 @@ void VersionStorageInfo::GenerateLevelFilesBrief(const MutableCFOptions& options
       if (LikelyIngestedFile(f, level)) {
         level_files_brief_[level].num_ingested_files += 1;
         level_files_brief_[level].num_ingested_bytes += f->fd.GetFileSize();
-        level_files_brief_[level].num_tolerant_bytes += static_cast<double>(options.ingest_tolerant_ratio) / (level - base_level_ + 1) * MaxBytesForLevel(level);
       }
+    }
+    if (level != 0) {
+      level_files_brief_[level].num_tolerant_bytes = static_cast<double>(options.ingest_tolerant_ratio) / (level - base_level_ + 1) * MaxBytesForLevel(level);
     }
   }
 }

--- a/db/version_set.cc
+++ b/db/version_set.cc
@@ -1577,7 +1577,7 @@ VersionStorageInfo::VersionStorageInfo(
     const InternalKeyComparator* internal_comparator,
     const Comparator* user_comparator, int levels,
     CompactionStyle compaction_style, VersionStorageInfo* ref_vstorage,
-    bool _force_consistency_checks, bool _dynamic_level_bytes)
+    bool _force_consistency_checks, bool dynamic_level_bytes)
     : internal_comparator_(internal_comparator),
       user_comparator_(user_comparator),
       // cfd is nullptr if Version is dummy
@@ -1605,7 +1605,7 @@ VersionStorageInfo::VersionStorageInfo(
       estimated_compaction_needed_bytes_(0),
       finalized_(false),
       force_consistency_checks_(_force_consistency_checks),
-      dynamic_level_bytes_(_dynamic_level_bytes) {
+      dynamic_level_bytes_(dynamic_level_bytes) {
   if (ref_vstorage != nullptr) {
     accumulated_file_size_ = ref_vstorage->accumulated_file_size_;
     accumulated_raw_key_size_ = ref_vstorage->accumulated_raw_key_size_;
@@ -1996,7 +1996,7 @@ void VersionStorageInfo::GenerateLevelFilesBrief(
     DoGenerateLevelFilesBrief(
         &level_files_brief_[level], files_[level], &arena_);
     for (const auto& f : files_[level]) {
-      if (LikelyIngestedFile(f, level)) {
+      if (CanIgnoreFile(f, level)) {
         level_files_brief_[level].num_ingested_files += 1;
         level_files_brief_[level].num_ingested_bytes += f->fd.GetFileSize();
       }

--- a/db/version_set.cc
+++ b/db/version_set.cc
@@ -2232,7 +2232,7 @@ void VersionStorageInfo::EstimateCompactionBytesNeeded(
 #ifndef NDEBUG
       uint64_t level_size2 = 0;
       for (auto* f : files_[level]) {
-        if (CanIgnoreFile(f, level)) continue;
+        if (mutable_cf_options.ingest_tolerant_ratio != 0 && CanIgnoreFile(f, level)) continue;
         level_size2 += f->fd.GetFileSize();
       }
       assert(level_size2 == bytes_next_level);
@@ -2241,7 +2241,7 @@ void VersionStorageInfo::EstimateCompactionBytesNeeded(
       bytes_next_level = 0;
     } else {
       for (auto* f : files_[level]) {
-        if (CanIgnoreFile(f, level)) continue;
+        if (mutable_cf_options.ingest_tolerant_ratio != 0 && CanIgnoreFile(f, level)) continue;
         level_size += f->fd.GetFileSize();
       }
     }
@@ -2261,7 +2261,7 @@ void VersionStorageInfo::EstimateCompactionBytesNeeded(
       assert(bytes_next_level == 0);
       if (level + 1 < num_levels_) {
         for (auto* f : files_[level + 1]) {
-          if (CanIgnoreFile(f, level + 1)) continue;
+          if (mutable_cf_options.ingest_tolerant_ratio != 0 && CanIgnoreFile(f, level + 1)) continue;
           bytes_next_level += f->fd.GetFileSize();
         }
       }
@@ -2373,7 +2373,7 @@ void VersionStorageInfo::ComputeCompactionScore(
       uint64_t ingest_files_size = 0;
       for (auto f : files_[level]) {
         if (!f->being_compacted) {
-          if (CanIgnoreFile(f, level)) {
+          if (mutable_cf_options.ingest_tolerant_ratio != 0 && CanIgnoreFile(f, level)) {
             ingest_files_size += f->compensated_file_size;
           } else {
             level_bytes_no_compacting += f->compensated_file_size;

--- a/db/version_set.cc
+++ b/db/version_set.cc
@@ -1546,16 +1546,6 @@ Status Version::OverlapWithLevelIterator(const ReadOptions& read_options,
       status = OverlapWithIterator(
           ucmp, smallest_user_key, largest_user_key, iter.get(), overlap);
       if (!status.ok() || *overlap) {
-        if (*overlap) {
-          ParsedInternalKey seek_result;
-          if (!ParseInternalKey(iter->key(), &seek_result)) {
-            return Status::Corruption("DB have corrupted keys");
-          }
-          ROCKS_LOG_INFO(info_log_, "overlap in L%d, range [%s, %s], seek: %s",
-                         level, smallest_user_key.ToString(true).c_str(),
-                         largest_user_key.ToString(true).c_str(),
-                         seek_result.DebugString(true).c_str());
-        }
         break;
       }
     }
@@ -1570,16 +1560,6 @@ Status Version::OverlapWithLevelIterator(const ReadOptions& read_options,
         &range_del_agg));
     status = OverlapWithIterator(
         ucmp, smallest_user_key, largest_user_key, iter.get(), overlap);
-    if (*overlap) {
-      ParsedInternalKey seek_result;
-      if (!ParseInternalKey(iter->key(), &seek_result)) {
-        return Status::Corruption("DB have corrupted keys");
-      }
-      ROCKS_LOG_INFO(info_log_, "overlap in L%d, range [%s, %s], seek: %s",
-                     level, smallest_user_key.ToString(true).c_str(),
-                     largest_user_key.ToString(true).c_str(),
-                     seek_result.DebugString(true).c_str());
-    }
   }
 
   if (status.ok() && *overlap == false &&

--- a/db/version_set.cc
+++ b/db/version_set.cc
@@ -774,6 +774,7 @@ void DoGenerateLevelFilesBrief(LevelFilesBrief* file_level,
   file_level->files = new (mem)FdWithKeyRange[num];
   file_level->num_ingested_files = 0;
   file_level->num_ingested_bytes = 0;
+  file_level->num_tolerant_bytes = 0;
 
   for (size_t i = 0; i < num; i++) {
     Slice smallest_key = files[i]->smallest.Encode();
@@ -1993,7 +1994,7 @@ void VersionStorageInfo::GenerateLevelFilesBrief(const MutableCFOptions& options
       if (LikelyIngestedFile(f, level)) {
         level_files_brief_[level].num_ingested_files += 1;
         level_files_brief_[level].num_ingested_bytes += f->fd.GetFileSize();
-        level_files_brief_[level].tolerant_bytes += static_cast<double>(options.ingest_tolerant_ratio) / (level - base_level_ + 1) * MaxBytesForLevel(level);
+        level_files_brief_[level].num_tolerant_bytes += static_cast<double>(options.ingest_tolerant_ratio) / (level - base_level_ + 1) * MaxBytesForLevel(level);
       }
     }
   }

--- a/db/version_set.h
+++ b/db/version_set.h
@@ -386,6 +386,7 @@ class VersionStorageInfo {
 
   // Returns maximum total bytes of data on a given level.
   uint64_t MaxBytesForLevel(int level) const;
+  uint64_t MaxStaticBytesForLevel(int level) const;
 
   // Must be called after any change to MutableCFOptions.
   void CalculateBaseBytes(const ImmutableCFOptions& ioptions,
@@ -426,6 +427,7 @@ class VersionStorageInfo {
                               // is guaranteed to be empty.
   // Per-level max bytes
   std::vector<uint64_t> level_max_bytes_;
+  std::vector<uint64_t> level_max_bytes_static_;
 
   // A short brief metadata of files per level
   autovector<rocksdb::LevelFilesBrief> level_files_brief_;

--- a/db/version_set.h
+++ b/db/version_set.h
@@ -188,6 +188,8 @@ class VersionStorageInfo {
   int MaxInputLevel() const;
   int MaxOutputLevel(bool allow_ingest_behind) const;
 
+  bool FileCanIgnore(FileMetaData* f, int level) const;
+
   // Return level number that has idx'th highest score
   int CompactionScoreLevel(int idx) const { return compaction_level_[idx]; }
 
@@ -272,6 +274,10 @@ class VersionStorageInfo {
     assert(level < static_cast<int>(level_files_brief_.size()));
     return level_files_brief_[level];
   }
+
+  int GetNumLevelIngestedFiles(int level) const;
+
+  uint64_t GetNumLevelIngestedBytes(int level) const;
 
   // REQUIRES: This version has been saved (see VersionSet::SaveTo)
   const std::vector<int>& FilesByCompactionPri(int level) const {
@@ -373,7 +379,7 @@ class VersionStorageInfo {
 
   double GetEstimatedCompressionRatioAtLevel(int level) const;
 
-  // re-initializes the index that is used to offset into
+  // e-initializes the index that is used to offset into
   // files_by_compaction_pri_
   // to find the next compaction candidate file.
   void ResetNextCompactionIndex(int level) {

--- a/db/version_set.h
+++ b/db/version_set.h
@@ -189,6 +189,7 @@ class VersionStorageInfo {
   int MaxOutputLevel(bool allow_ingest_behind) const;
 
   bool FileCanIgnore(FileMetaData* f, int level) const;
+  bool LikelyIngestedFile(FileMetaData* f, int level) const;
 
   // Return level number that has idx'th highest score
   int CompactionScoreLevel(int idx) const { return compaction_level_[idx]; }
@@ -274,10 +275,6 @@ class VersionStorageInfo {
     assert(level < static_cast<int>(level_files_brief_.size()));
     return level_files_brief_[level];
   }
-
-  int GetNumLevelIngestedFiles(int level) const;
-
-  uint64_t GetNumLevelIngestedBytes(int level) const;
 
   // REQUIRES: This version has been saved (see VersionSet::SaveTo)
   const std::vector<int>& FilesByCompactionPri(int level) const {
@@ -379,7 +376,7 @@ class VersionStorageInfo {
 
   double GetEstimatedCompressionRatioAtLevel(int level) const;
 
-  // e-initializes the index that is used to offset into
+  // re-initializes the index that is used to offset into
   // files_by_compaction_pri_
   // to find the next compaction candidate file.
   void ResetNextCompactionIndex(int level) {
@@ -392,7 +389,6 @@ class VersionStorageInfo {
 
   // Returns maximum total bytes of data on a given level.
   uint64_t MaxBytesForLevel(int level) const;
-  uint64_t MaxStaticBytesForLevel(int level) const;
 
   // Must be called after any change to MutableCFOptions.
   void CalculateBaseBytes(const ImmutableCFOptions& ioptions,
@@ -433,7 +429,6 @@ class VersionStorageInfo {
                               // is guaranteed to be empty.
   // Per-level max bytes
   std::vector<uint64_t> level_max_bytes_;
-  std::vector<uint64_t> level_max_bytes_static_;
 
   // A short brief metadata of files per level
   autovector<rocksdb::LevelFilesBrief> level_files_brief_;
@@ -540,6 +535,7 @@ class VersionStorageInfo {
   // If set to true, we will run consistency checks even if RocksDB
   // is compiled in release mode
   bool force_consistency_checks_;
+  bool dynamic_level_bytes_;
 
   friend class Version;
   friend class VersionSet;

--- a/db/version_set.h
+++ b/db/version_set.h
@@ -164,7 +164,7 @@ class VersionStorageInfo {
   void ComputeBottommostFilesMarkedForCompaction();
 
   // Generate level_files_brief_ from files_
-  void GenerateLevelFilesBrief();
+  void GenerateLevelFilesBrief(const MutableCFOptions& options);
   // Sort all files for this version based on their file size and
   // record results in files_by_compaction_pri_. The largest files are listed
   // first.

--- a/db/version_set.h
+++ b/db/version_set.h
@@ -101,7 +101,7 @@ class VersionStorageInfo {
                      const Comparator* user_comparator, int num_levels,
                      CompactionStyle compaction_style,
                      VersionStorageInfo* src_vstorage,
-                     bool _force_consistency_checks);
+                     bool _force_consistency_checks, bool _dynamic_level_bytes);
   ~VersionStorageInfo();
 
   void Reserve(int level, size_t size) { files_[level].reserve(size); }

--- a/db/version_set.h
+++ b/db/version_set.h
@@ -188,7 +188,7 @@ class VersionStorageInfo {
   int MaxInputLevel() const;
   int MaxOutputLevel(bool allow_ingest_behind) const;
 
-  bool FileCanIgnore(FileMetaData* f, int level) const;
+  bool CanIgnoreFile(FileMetaData* f, int level) const;
   bool LikelyIngestedFile(FileMetaData* f, int level) const;
 
   // Return level number that has idx'th highest score

--- a/db/version_set_test.cc
+++ b/db/version_set_test.cc
@@ -387,8 +387,8 @@ TEST_F(VersionStorageInfoTest, GetOverlappingInputs) {
   Add(1, 5U, {"g", 0, kTypeValue}, {"h", 0, kTypeValue}, 1);
   Add(1, 6U, {"i", 0, kTypeValue}, {"j", 0, kTypeValue}, 1);
   vstorage_.UpdateNumNonEmptyLevels();
-  MutableCFOptions opt;
-  vstorage_.GenerateLevelFilesBrief(opt);
+  vstorage_.CalculateBaseBytes(ioptions_, mutable_cf_options_);
+  vstorage_.GenerateLevelFilesBrief(mutable_cf_options_);
 
   ASSERT_EQ("1,2", GetOverlappingFiles(
       1, {"a", 0, kTypeValue}, {"b", 0, kTypeValue}));

--- a/db/version_set_test.cc
+++ b/db/version_set_test.cc
@@ -387,7 +387,8 @@ TEST_F(VersionStorageInfoTest, GetOverlappingInputs) {
   Add(1, 5U, {"g", 0, kTypeValue}, {"h", 0, kTypeValue}, 1);
   Add(1, 6U, {"i", 0, kTypeValue}, {"j", 0, kTypeValue}, 1);
   vstorage_.UpdateNumNonEmptyLevels();
-  vstorage_.GenerateLevelFilesBrief();
+  MutableCFOptions opt;
+  vstorage_.GenerateLevelFilesBrief(opt);
 
   ASSERT_EQ("1,2", GetOverlappingFiles(
       1, {"a", 0, kTypeValue}, {"b", 0, kTypeValue}));

--- a/include/rocksdb/advanced_options.h
+++ b/include/rocksdb/advanced_options.h
@@ -483,7 +483,8 @@ struct AdvancedColumnFamilyOptions {
   // Default: false
   bool level_compaction_dynamic_level_bytes = false;
 
-  // The ratio that tolerates ingested files not to trigger compaction if the total size of the level exceed the max level bytes.
+  // The ratio that tolerates ingested files not to trigger compaction if the
+  // total size of the level exceed the max level bytes.
   // Only useful when level_compaction_dynamic_level_bytes is enabled.
   //
   // Default: 0

--- a/include/rocksdb/advanced_options.h
+++ b/include/rocksdb/advanced_options.h
@@ -483,6 +483,12 @@ struct AdvancedColumnFamilyOptions {
   // Default: false
   bool level_compaction_dynamic_level_bytes = false;
 
+  // The ratio that tolerates ingested files not to trigger compaction if the total size of the level exceed the max level bytes.
+  // Only useful when level_compaction_dynamic_level_bytes is enabled.
+  //
+  // Default: 0
+  size_t ingest_tolerant_ratio = 0;
+
   // Default: 10.
   //
   // Dynamically changeable through SetOptions() API

--- a/include/rocksdb/advanced_options.h
+++ b/include/rocksdb/advanced_options.h
@@ -483,9 +483,13 @@ struct AdvancedColumnFamilyOptions {
   // Default: false
   bool level_compaction_dynamic_level_bytes = false;
 
-  // The ratio that tolerates ingested files not to trigger compaction if the
-  // total size of the level exceed the max level bytes.
-  // Only useful when level_compaction_dynamic_level_bytes is enabled.
+  // The ratio to calcuate the total tolerant bytes of ingested files for one
+  // level.
+  // tolerant_bytes = ingest_tolerant_ratio /
+  //                  (level - base_level + 1) * level_max_bytes.
+  // With ingest tolerant bytes, the compaction wouldn't be triggered until
+  // bytes_without_ingest + ingest_bytes > level_max_bytes + tolerant_bytes.
+  // Only effective when level_compaction_dynamic_level_bytes is enabled.
   //
   // Default: 0
   size_t ingest_tolerant_ratio = 0;

--- a/include/rocksdb/db.h
+++ b/include/rocksdb/db.h
@@ -541,6 +541,7 @@ class DB {
     static const std::string kNumIngestedFilesAtLevelPrefix;
     
     static const std::string kNumIngestedBytesAtLevelPrefix;
+    static const std::string kNumTolerantBytesAtLevelPrefix;
 
     //  "rocksdb.compression-ratio-at-level<N>" - returns string containing the
     //      compression ratio of data at level <N>, where <N> is an ASCII

--- a/include/rocksdb/db.h
+++ b/include/rocksdb/db.h
@@ -538,6 +538,8 @@ class DB {
     //      level number (e.g., "0").
     static const std::string kNumFilesAtLevelPrefix;
 
+    static const std::string kNumMaxBytesAtLevelPrefix;
+
     //  "rocksdb.num-ingested-files-at-level<N>" - returns string containing the
     //  number of ingested files at level <N>.
     static const std::string kNumIngestedFilesAtLevelPrefix;

--- a/include/rocksdb/db.h
+++ b/include/rocksdb/db.h
@@ -538,9 +538,16 @@ class DB {
     //      level number (e.g., "0").
     static const std::string kNumFilesAtLevelPrefix;
 
+    //  "rocksdb.num-ingested-files-at-level<N>" - returns string containing the
+    //  number of ingested files at level <N>.
     static const std::string kNumIngestedFilesAtLevelPrefix;
-    
+
+    //  "rocksdb.num-ingested-bytes-at-level<N>" - returns string containing the
+    //  number of ingested bytes at level <N>.
     static const std::string kNumIngestedBytesAtLevelPrefix;
+
+    //  "rocksdb.num-tolerant-bytes-at-level<N>" - returns string containing the
+    //  number of tolerant bytes for ingestion at level <N>.
     static const std::string kNumTolerantBytesAtLevelPrefix;
 
     //  "rocksdb.compression-ratio-at-level<N>" - returns string containing the

--- a/include/rocksdb/db.h
+++ b/include/rocksdb/db.h
@@ -538,6 +538,10 @@ class DB {
     //      level number (e.g., "0").
     static const std::string kNumFilesAtLevelPrefix;
 
+    static const std::string kNumIngestedFilesAtLevelPrefix;
+    
+    static const std::string kNumIngestedBytesAtLevelPrefix;
+
     //  "rocksdb.compression-ratio-at-level<N>" - returns string containing the
     //      compression ratio of data at level <N>, where <N> is an ASCII
     //      representation of a level number (e.g., "0"). Here, compression

--- a/include/rocksdb/listener.h
+++ b/include/rocksdb/listener.h
@@ -261,6 +261,8 @@ struct ExternalFileIngestionInfo {
   SequenceNumber global_seqno;
   // Table properties of the table being flushed
   TableProperties table_properties;
+  // Level that the external file is ingested into
+  int picked_level;
 };
 
 // EventListener class contains a set of callback functions that will

--- a/options/cf_options.h
+++ b/options/cf_options.h
@@ -159,6 +159,7 @@ struct MutableCFOptions {
             options.max_bytes_for_level_multiplier_additional),
         compaction_options_fifo(options.compaction_options_fifo),
         compaction_options_universal(options.compaction_options_universal),
+        ingest_tolerant_ratio(options.ingest_tolerant_ratio),
         max_sequential_skip_in_iterations(
             options.max_sequential_skip_in_iterations),
         paranoid_file_checks(options.paranoid_file_checks),
@@ -193,6 +194,7 @@ struct MutableCFOptions {
         ttl(0),
         periodic_compaction_seconds(0),
         compaction_options_fifo(),
+        ingest_tolerant_ratio(0),
         max_sequential_skip_in_iterations(0),
         paranoid_file_checks(false),
         report_bg_io_stats(false),
@@ -247,6 +249,7 @@ struct MutableCFOptions {
   std::vector<int> max_bytes_for_level_multiplier_additional;
   CompactionOptionsFIFO compaction_options_fifo;
   CompactionOptionsUniversal compaction_options_universal;
+  size_t ingest_tolerant_ratio;
 
   // Misc options
   uint64_t max_sequential_skip_in_iterations;

--- a/options/options_helper.cc
+++ b/options/options_helper.cc
@@ -187,6 +187,7 @@ ColumnFamilyOptions BuildColumnFamilyOptions(
   cf_opts.ttl = mutable_cf_options.ttl;
   cf_opts.periodic_compaction_seconds =
       mutable_cf_options.periodic_compaction_seconds;
+  cf_opts.ingest_tolerant_ratio = mutable_cf_options.ingest_tolerant_ratio;
 
   cf_opts.max_bytes_for_level_multiplier_additional.clear();
   for (auto value :
@@ -2033,7 +2034,11 @@ std::unordered_map<std::string, OptionTypeInfo>
         {"sample_for_compression",
          {offset_of(&ColumnFamilyOptions::sample_for_compression),
           OptionType::kUInt64T, OptionVerificationType::kNormal, true,
-          offsetof(struct MutableCFOptions, sample_for_compression)}}};
+          offsetof(struct MutableCFOptions, sample_for_compression)}},
+        {"ingest_tolerant_ratio",
+         {offset_of(&ColumnFamilyOptions::ingest_tolerant_ratio),
+          OptionType::kSizeT, OptionVerificationType::kNormal, true,
+          offsetof(struct MutableCFOptions, ingest_tolerant_ratio)}}};
 
 std::unordered_map<std::string, OptionTypeInfo>
     OptionsHelper::fifo_compaction_options_type_info = {

--- a/options/options_settable_test.cc
+++ b/options/options_settable_test.cc
@@ -462,7 +462,7 @@ TEST_F(OptionsSettableTest, ColumnFamilyOptionsAllFieldsSettable) {
       "sample_for_compression=0;"
       "compaction_options_fifo={max_table_files_size=3;allow_"
       "compaction=false;};"
-      "tolerant_ingest_ratio=5;",
+      "ingest_tolerant_ratio=5;",
       new_options));
 
   ASSERT_EQ(unset_bytes_base,

--- a/options/options_settable_test.cc
+++ b/options/options_settable_test.cc
@@ -461,7 +461,8 @@ TEST_F(OptionsSettableTest, ColumnFamilyOptionsAllFieldsSettable) {
       "periodic_compaction_seconds=3600;"
       "sample_for_compression=0;"
       "compaction_options_fifo={max_table_files_size=3;allow_"
-      "compaction=false;};",
+      "compaction=false;};"
+      "tolerant_ingest_ratio=5;",
       new_options));
 
   ASSERT_EQ(unset_bytes_base,

--- a/options/options_test.cc
+++ b/options/options_test.cc
@@ -97,6 +97,7 @@ TEST_F(OptionsTest, GetOptionsFromMapTest) {
       {"min_partial_merge_operands", "31"},
       {"prefix_extractor", "fixed:31"},
       {"optimize_filters_for_hits", "true"},
+      {"ingest_tolerant_ratio", "10"},
   };
 
   std::unordered_map<std::string, std::string> db_options_map = {
@@ -207,6 +208,7 @@ TEST_F(OptionsTest, GetOptionsFromMapTest) {
   ASSERT_EQ(new_cf_opt.max_successive_merges, 30U);
   ASSERT_TRUE(new_cf_opt.prefix_extractor != nullptr);
   ASSERT_EQ(new_cf_opt.optimize_filters_for_hits, true);
+  ASSERT_EQ(new_cf_opt.ingest_tolerant_ratio, 10U);
   ASSERT_EQ(std::string(new_cf_opt.prefix_extractor->Name()),
             "rocksdb.FixedPrefix.31");
 


### PR DESCRIPTION
With dynamic_level_bytes enabled, all the non-empty levels should be close to dynamic level bytes all the time, so for an ingested file which can't be ingested to the last level directly, it is highly possible to trigger compaction in quick succession.

Assume max_bytes_for_level_multiplier=10, num_levels=7,and max_bytes_for_level_base=100MB.
Target sizes of level 1 to 6 should be:
[- - 100MB 1G 10G 100G]
with base level is level 3.

The actual size of each level maybe:
[- - 80MB 900MB 9.9G 90G]
Now, here comes a file of 100M+ which ingests into L5 directly. Then for level 5: 9.9G + 100M > 10G. So the compaction of that level should be triggered.
If there are a lot of ingestions in L0-L5, almost every ingest will trigger compaction which causes higher compaction flow.

Note that, if base_level is advanced, the target sizes of each level should be:
[- 100M 1G 10G 100G 1000G]
If the base_level is advanced later, there is enough room for the ingest file to be placed at the current level. We can just tolerate the ingest files breaking the perfect LSM shape of dynamic_level_bytes, so the burst compaction flow can be amortized in the future. Though it may worse space amplification. Considering the size of ingested files only constitutes a small proportion of the whole data, the impact is acceptable comparing to higher compaction flow at the ingestion point.

This PR does:
- Add an `ingested_file` field of file metadata which is persistent.
- Skip ingested files when calculating compaction score and pending compaction bytes.


Test:
Run sysbench insert workload with a lots of ingestion. Left is this PR and right is the master branch.
![image](https://user-images.githubusercontent.com/13497871/95991050-dea4f780-0e5e-11eb-8b3b-4564b6e545a9.png)
![image](https://user-images.githubusercontent.com/13497871/95991095-eebcd700-0e5e-11eb-8a0b-0835b7e26f73.png)


