### PR TITLE
Use absolute value as lower bound for WriteAmpBasedRateLimiter's limit

### DIFF
--- a/utilities/rate_limiters/write_amp_based_rate_limiter.cc
+++ b/utilities/rate_limiters/write_amp_based_rate_limiter.cc
@@ -268,7 +268,7 @@ int64_t WriteAmpBasedRateLimiter::CalculateRefillBytesPerPeriod(
 
 Status WriteAmpBasedRateLimiter::Tune() {
   // computed rate limit will be larger than `kMinBytesPerSec`
-  const int kMinBytesPerSec = 10 * 1024 * 1024;  // 10 MB/s
+  const int64_t kMinBytesPerSec = 10 * 1024 * 1024;
   // high-priority bytes are padded to 20MB
   const int64_t kHighBytesLower = 20 * 1024 * 1024;
   // lower bound for write amplification estimation

--- a/utilities/rate_limiters/write_amp_based_rate_limiter.cc
+++ b/utilities/rate_limiters/write_amp_based_rate_limiter.cc
@@ -267,9 +267,8 @@ int64_t WriteAmpBasedRateLimiter::CalculateRefillBytesPerPeriod(
 }
 
 Status WriteAmpBasedRateLimiter::Tune() {
-  // computed rate limit will be larger than
-  // `max_bytes_per_sec_ / kAllowedRangeFactor`
-  const int kAllowedRangeFactor = 20;
+  // computed rate limit will be larger than `kMinBytesPerSec`
+  const int kMinBytesPerSec = 10 * 1024 * 1024;  // 10 MB/s
   // high-priority bytes are padded to 20MB
   const int64_t kHighBytesLower = 20 * 1024 * 1024;
   // lower bound for write amplification estimation
@@ -323,7 +322,7 @@ Status WriteAmpBasedRateLimiter::Tune() {
       (ratio + ratio_padding + ratio_delta_) *
       std::max(highpri_bytes_sampler_.GetRecentValue(), kHighBytesLower) / 10;
   new_bytes_per_sec = std::max(
-      max_bytes_per_sec_ / kAllowedRangeFactor,
+      kMinBytesPerSec,
       std::min(new_bytes_per_sec,
                max_bytes_per_sec_ - highpri_bytes_sampler_.GetRecentValue()));
   if (new_bytes_per_sec != prev_bytes_per_sec) {


### PR DESCRIPTION
Signed-off-by: tabokie <xy.tao@outlook.com>

So that we can use a huge value as upper bound without losing the ability to adapt to normal pressure.