### PR TITLE
table_cache: Generate unique ID based on db instance, file number

### DIFF
--- a/db/table_cache.h
+++ b/db/table_cache.h
@@ -193,6 +193,9 @@ class TableCache {
   std::string row_cache_id_;
   bool immortal_tables_;
   BlockCacheTracer* const block_cache_tracer_;
+  const uint64_t cache_id_;
+
+  static std::atomic<uint64_t> cache_id_alloc;
 };
 
 }  // namespace rocksdb

--- a/env/env_encryption.cc
+++ b/env/env_encryption.cc
@@ -173,6 +173,8 @@ class EncryptedRandomAccessFile : public RandomAccessFile {
     return file_->GetUniqueId(id, max_size);
   };
 
+  void SetUniqueId(std::string unique_id) { file_->SetUniqueId(unique_id); }
+
   void Hint(AccessPattern pattern) override { file_->Hint(pattern); }
 
   // Indicates the upper layers if the current RandomAccessFile implementation

--- a/env/env_encryption.cc
+++ b/env/env_encryption.cc
@@ -173,7 +173,9 @@ class EncryptedRandomAccessFile : public RandomAccessFile {
     return file_->GetUniqueId(id, max_size);
   };
 
-  void SetUniqueId(std::string unique_id) { file_->SetUniqueId(unique_id); }
+  void SetUniqueId(std::string unique_id) override {
+    file_->SetUniqueId(unique_id);
+  }
 
   void Hint(AccessPattern pattern) override { file_->Hint(pattern); }
 

--- a/env/env_test.cc
+++ b/env/env_test.cc
@@ -1132,7 +1132,7 @@ TEST_P(EnvPosixTestWithParam, RandomAccessUniqueIDConcurrent) {
     }
 
     // Delete the files
-    for (const std::string fname : fnames) {
+    for (const std::string& fname : fnames) {
       ASSERT_OK(env_->DeleteFile(fname));
     }
 

--- a/env/io_posix.h
+++ b/env/io_posix.h
@@ -50,11 +50,6 @@ static Status IOError(const std::string& context, const std::string& file_name,
   }
 }
 
-class PosixHelper {
- public:
-  static size_t GetUniqueIdFromFile(int fd, char* id, size_t max_size);
-};
-
 class PosixSequentialFile : public SequentialFile {
  private:
   std::string filename_;
@@ -96,9 +91,6 @@ class PosixRandomAccessFile : public RandomAccessFile {
 
   virtual Status Prefetch(uint64_t offset, size_t n) override;
 
-#if defined(OS_LINUX) || defined(OS_MACOSX) || defined(OS_AIX)
-  virtual size_t GetUniqueId(char* id, size_t max_size) const override;
-#endif
   virtual void Hint(AccessPattern pattern) override;
   virtual Status InvalidateCache(size_t offset, size_t length) override;
   virtual bool use_direct_io() const override { return use_direct_io_; }
@@ -150,9 +142,6 @@ class PosixWritableFile : public WritableFile {
   virtual Status Allocate(uint64_t offset, uint64_t len) override;
 #endif
   virtual Status RangeSync(uint64_t offset, uint64_t nbytes) override;
-#ifdef OS_LINUX
-  virtual size_t GetUniqueId(char* id, size_t max_size) const override;
-#endif
 };
 
 // mmap() based random-access

--- a/include/rocksdb/env.h
+++ b/include/rocksdb/env.h
@@ -612,6 +612,8 @@ struct ReadRequest {
 
 // A file abstraction for randomly reading the contents of a file.
 class RandomAccessFile {
+ private:
+  std::string unique_id_;
  public:
   RandomAccessFile() {}
   virtual ~RandomAccessFile();
@@ -665,10 +667,18 @@ class RandomAccessFile {
   // a single varint.
   //
   // Note: these IDs are only valid for the duration of the process.
-  virtual size_t GetUniqueId(char* /*id*/, size_t /*max_size*/) const {
-    return 0;  // Default implementation to prevent issues with backwards
-               // compatibility.
-  };
+  virtual size_t GetUniqueId(char* id, size_t max_size) const {
+    if (max_size >= unique_id_.length()) {
+      memcpy(id, unique_id_.data(), unique_id_.length());
+      return unique_id_.length();
+    }
+    return 0;
+  }
+
+  // Sets a unique ID for this file that could be returned in GetUniqueId.
+  virtual void SetUniqueId(std::string unique_id) {
+    unique_id_ = std::move(unique_id);
+  }
 
   enum AccessPattern { NORMAL, RANDOM, SEQUENTIAL, WILLNEED, DONTNEED };
 
@@ -807,8 +817,17 @@ class WritableFile {
   }
 
   // For documentation, refer to RandomAccessFile::GetUniqueId()
-  virtual size_t GetUniqueId(char* /*id*/, size_t /*max_size*/) const {
-    return 0;  // Default implementation to prevent issues with backwards
+  virtual size_t GetUniqueId(char* id, size_t max_size) const {
+    if (max_size >= unique_id_.length()) {
+      memcpy(id, unique_id_.data(), unique_id_.length());
+      return unique_id_.length();
+    }
+    return 0;
+  }
+
+  // Sets a unique ID for this file that could be returned in GetUniqueId.
+  virtual void SetUniqueId(std::string unique_id) {
+    unique_id_ = unique_id;
   }
 
   // Remove any kind of caching of data from the offset to offset+length
@@ -870,6 +889,7 @@ class WritableFile {
  private:
   size_t last_preallocated_block_;
   size_t preallocation_block_size_;
+  std::string unique_id_;
   // No copying allowed
   WritableFile(const WritableFile&);
   void operator=(const WritableFile&);
@@ -1407,6 +1427,9 @@ class RandomAccessFileWrapper : public RandomAccessFile {
   size_t GetUniqueId(char* id, size_t max_size) const override {
     return target_->GetUniqueId(id, max_size);
   };
+  void SetUniqueId(std::string unique_id) override {
+    target_->SetUniqueId(unique_id);
+  }
   void Hint(AccessPattern pattern) override { target_->Hint(pattern); }
   bool use_direct_io() const override { return target_->use_direct_io(); }
   size_t GetRequiredBufferAlignment() const override {
@@ -1468,6 +1491,10 @@ class WritableFileWrapper : public WritableFile {
 
   size_t GetUniqueId(char* id, size_t max_size) const override {
     return target_->GetUniqueId(id, max_size);
+  }
+
+  void SetUniqueId(std::string unique_id) override {
+    target_->SetUniqueId(unique_id);
   }
 
   Status InvalidateCache(size_t offset, size_t length) override {

--- a/include/rocksdb/env.h
+++ b/include/rocksdb/env.h
@@ -827,7 +827,7 @@ class WritableFile {
   }
 
   // Sets a unique ID for this file that could be returned in GetUniqueId.
-  virtual void SetUniqueId(std::string unique_id) { unique_id_ = unique_id; }
+  virtual void SetUniqueId(std::string unique_id) { unique_id_ = std::move(unique_id); }
 
   // Remove any kind of caching of data from the offset to offset+length
   // of this file. If the length is 0, then it refers to the end of file.

--- a/include/rocksdb/env.h
+++ b/include/rocksdb/env.h
@@ -614,6 +614,7 @@ struct ReadRequest {
 class RandomAccessFile {
  private:
   std::string unique_id_;
+
  public:
   RandomAccessFile() {}
   virtual ~RandomAccessFile();
@@ -826,9 +827,7 @@ class WritableFile {
   }
 
   // Sets a unique ID for this file that could be returned in GetUniqueId.
-  virtual void SetUniqueId(std::string unique_id) {
-    unique_id_ = unique_id;
-  }
+  virtual void SetUniqueId(std::string unique_id) { unique_id_ = unique_id; }
 
   // Remove any kind of caching of data from the offset to offset+length
   // of this file. If the length is 0, then it refers to the end of file.

--- a/include/rocksdb/env.h
+++ b/include/rocksdb/env.h
@@ -827,7 +827,9 @@ class WritableFile {
   }
 
   // Sets a unique ID for this file that could be returned in GetUniqueId.
-  virtual void SetUniqueId(std::string unique_id) { unique_id_ = std::move(unique_id); }
+  virtual void SetUniqueId(std::string unique_id) {
+    unique_id_ = std::move(unique_id);
+  }
 
   // Remove any kind of caching of data from the offset to offset+length
   // of this file. If the length is 0, then it refers to the end of file.

--- a/port/win/io_win.h
+++ b/port/win/io_win.h
@@ -56,8 +56,6 @@ Status fallocate(const std::string& filename, HANDLE hFile, uint64_t to_size);
 
 Status ftruncate(const std::string& filename, HANDLE hFile, uint64_t toSize);
 
-size_t GetUniqueIdFromFile(HANDLE hFile, char* id, size_t max_size);
-
 class WinFileData {
  protected:
   const std::string filename_;
@@ -143,8 +141,6 @@ class WinMmapReadableFile : private WinFileData, public RandomAccessFile {
                       char* scratch) const override;
 
   virtual Status InvalidateCache(size_t offset, size_t length) override;
-
-  virtual size_t GetUniqueId(char* id, size_t max_size) const override;
 };
 
 // We preallocate and use memcpy to append new
@@ -225,8 +221,6 @@ class WinMmapFile : private WinFileData, public WritableFile {
   virtual Status InvalidateCache(size_t offset, size_t length) override;
 
   virtual Status Allocate(uint64_t offset, uint64_t len) override;
-
-  virtual size_t GetUniqueId(char* id, size_t max_size) const override;
 };
 
 class WinRandomAccessImpl {
@@ -268,8 +262,6 @@ class WinRandomAccessFile
 
   virtual Status Read(uint64_t offset, size_t n, Slice* result,
                       char* scratch) const override;
-
-  virtual size_t GetUniqueId(char* id, size_t max_size) const override;
 
   virtual bool use_direct_io() const override { return WinFileData::use_direct_io(); }
 
@@ -374,8 +366,6 @@ class WinWritableFile : private WinFileData,
   virtual uint64_t GetFileSize() override;
 
   virtual Status Allocate(uint64_t offset, uint64_t len) override;
-
-  virtual size_t GetUniqueId(char* id, size_t max_size) const override;
 };
 
 class WinRandomRWFile : private WinFileData,
@@ -437,8 +427,6 @@ class WinDirectory : public Directory {
     ::CloseHandle(handle_);
   }
   virtual Status Fsync() override;
-
-  size_t GetUniqueId(char* id, size_t max_size) const override;
 };
 
 class WinFileLock : public FileLock {

--- a/util/file_reader_writer.cc
+++ b/util/file_reader_writer.cc
@@ -695,7 +695,9 @@ class ReadaheadRandomAccessFile : public RandomAccessFile {
    return file_->GetUniqueId(id, max_size);
  }
 
- void SetUniqueId(std::string unique_id) { file_->SetUniqueId(unique_id); }
+ void SetUniqueId(std::string unique_id) override {
+   file_->SetUniqueId(unique_id);
+ }
 
  void Hint(AccessPattern pattern) override { file_->Hint(pattern); }
 

--- a/util/file_reader_writer.cc
+++ b/util/file_reader_writer.cc
@@ -695,6 +695,8 @@ class ReadaheadRandomAccessFile : public RandomAccessFile {
    return file_->GetUniqueId(id, max_size);
  }
 
+ void SetUniqueId(std::string unique_id) { file_->SetUniqueId(unique_id); }
+
  void Hint(AccessPattern pattern) override { file_->Hint(pattern); }
 
  Status InvalidateCache(size_t offset, size_t length) override {

--- a/utilities/env_mirror.cc
+++ b/utilities/env_mirror.cc
@@ -92,6 +92,8 @@ class RandomAccessFileMirror : public RandomAccessFile {
     // NOTE: not verified
     return a_->GetUniqueId(id, max_size);
   }
+
+  void SetUniqueId(std::string unique_id) { a_->SetUniqueId(unique_id); }
 };
 
 class WritableFileMirror : public WritableFile {

--- a/utilities/env_mirror.cc
+++ b/utilities/env_mirror.cc
@@ -93,7 +93,9 @@ class RandomAccessFileMirror : public RandomAccessFile {
     return a_->GetUniqueId(id, max_size);
   }
 
-  void SetUniqueId(std::string unique_id) { a_->SetUniqueId(unique_id); }
+  void SetUniqueId(std::string unique_id) override {
+    a_->SetUniqueId(unique_id);
+  }
 };
 
 class WritableFileMirror : public WritableFile {


### PR DESCRIPTION
This change updates the cache key prefix for SST files from relying
on the inode generation number to using a passed-in unique ID. This
ID is composed of a table-cache-specific random ID, as well as the
number of the SST. This should resolve issues around cache collisions
between two different SS tables that happened to have the same
generation number.

Cherry-pick of https://github.com/cockroachdb/rocksdb/pull/61