### PR TITLE
Pace up limiter before triggering write stall

### DIFF
--- a/db/column_family.cc
+++ b/db/column_family.cc
@@ -713,6 +713,10 @@ ColumnFamilyData::GetWriteStallConditionAndCause(
              mutable_cf_options.soft_pending_compaction_bytes_limit > 0 &&
              num_compaction_needed_bytes >=
                  mutable_cf_options.soft_pending_compaction_bytes_limit) {
+    fprintf(
+        stderr, "pending stall when %lu MB need and %lu MB limited\n",
+        num_compaction_needed_bytes / 1024 / 1024,
+        mutable_cf_options.soft_pending_compaction_bytes_limit / 1024 / 1024);
     return {WriteStallCondition::kDelayed,
             WriteStallCause::kPendingCompactionBytes};
   }
@@ -881,8 +885,11 @@ WriteStallCondition ColumnFamilyData::RecalculateWriteStallConditions(
               0.8 * mutable_cf_options.level0_slowdown_writes_trigger ||
           vstorage->estimated_compaction_needed_bytes() >=
               0.8 * mutable_cf_options.soft_pending_compaction_bytes_limit) {
+        fprintf(stderr, "request sent to limiter\n");
         rate_limiter->RequestPaceUp();
       }
+    } else {
+      fprintf(stderr, "limiter is null!\n");
     }
     prev_compaction_needed_bytes_ = compaction_needed_bytes;
   }

--- a/db/column_family.cc
+++ b/db/column_family.cc
@@ -721,9 +721,6 @@ ColumnFamilyData::GetWriteStallConditionAndCause(
 
 WriteStallCondition ColumnFamilyData::RecalculateWriteStallConditions(
     const MutableCFOptions& mutable_cf_options, RateLimiter* rate_limiter) {
-  if (rate_limiter) {
-    rate_limiter->SetBytesPerSecond(0);
-  }
   auto write_stall_condition = WriteStallCondition::kNormal;
   if (current_ != nullptr) {
     auto* vstorage = current_->storage_info();

--- a/db/column_family.h
+++ b/db/column_family.h
@@ -479,7 +479,8 @@ class ColumnFamilyData {
   // DBImpl::MakeRoomForWrite function to decide, if it need to make
   // a write stall
   WriteStallCondition RecalculateWriteStallConditions(
-      const MutableCFOptions& mutable_cf_options);
+      const MutableCFOptions& mutable_cf_options,
+      RateLimiter* rate_limiter = nullptr);
 
   void set_initialized() { initialized_.store(true); }
 

--- a/include/rocksdb/rate_limiter.h
+++ b/include/rocksdb/rate_limiter.h
@@ -101,6 +101,8 @@ class RateLimiter {
     return true;
   }
 
+  virtual void RequestPaceUp() {}
+
  protected:
   Mode GetMode() { return mode_; }
 

--- a/utilities/rate_limiters/write_amp_based_rate_limiter.cc
+++ b/utilities/rate_limiters/write_amp_based_rate_limiter.cc
@@ -328,7 +328,11 @@ Status WriteAmpBasedRateLimiter::Tune() {
     ratio_delta_ -= 1;
   }
   if (pace_up_request_.load(std::memory_order_relaxed)) {
-    ratio_delta_ += 60;  // effect lasts for at least 60 * kSecondsPerTune = 1m
+    fprintf(stderr, "received pace up request\n");
+    if (ratio_delta_ < 60) {
+      fprintf(stderr, "applied pace up request\n");
+      ratio_delta_ += 60;  // effect lasts for at least 60 * kSecondsPerTune = 1m
+    }
     pace_up_request_.store(false, std::memory_order_relaxed);
   }
 

--- a/utilities/rate_limiters/write_amp_based_rate_limiter.cc
+++ b/utilities/rate_limiters/write_amp_based_rate_limiter.cc
@@ -51,6 +51,7 @@ WriteAmpBasedRateLimiter::WriteAmpBasedRateLimiter(int64_t rate_bytes_per_sec,
       tuned_time_(NowMicrosMonotonic(env_)),
       duration_highpri_bytes_through_(0),
       duration_bytes_through_(0),
+      pace_up_request_(false),
       ratio_delta_(0) {
   total_requests_[0] = 0;
   total_requests_[1] = 0;
@@ -326,6 +327,10 @@ Status WriteAmpBasedRateLimiter::Tune() {
   } else if (util < 95 && ratio_delta_ > 0) {
     ratio_delta_ -= 1;
   }
+  if (pace_up_request_.load(std::memory_order_relaxed)) {
+    ratio_delta_ += 60;  // effect lasts for at least 60 * kSecondsPerTune = 1m
+    pace_up_request_.store(false, std::memory_order_relaxed);
+  }
 
   int64_t new_bytes_per_sec =
       (ratio + ratio_padding + ratio_delta_) *
@@ -342,6 +347,12 @@ Status WriteAmpBasedRateLimiter::Tune() {
   duration_bytes_through_ = 0;
   duration_highpri_bytes_through_ = 0;
   return Status::OK();
+}
+
+void WriteAmpBasedRateLimiter::RequestPaceUp() {
+  if (auto_tuned_) {
+    pace_up_request_.store(true, std::memory_order_relaxed);
+  }
 }
 
 RateLimiter* NewWriteAmpBasedRateLimiter(

--- a/utilities/rate_limiters/write_amp_based_rate_limiter.h
+++ b/utilities/rate_limiters/write_amp_based_rate_limiter.h
@@ -67,6 +67,8 @@ class WriteAmpBasedRateLimiter : public RateLimiter {
     return rate_bytes_per_sec_;
   }
 
+  virtual void RequestPaceUp() override;
+
  private:
   void Refill();
   int64_t CalculateRefillBytesPerPeriod(int64_t rate_bytes_per_sec);
@@ -149,6 +151,7 @@ class WriteAmpBasedRateLimiter : public RateLimiter {
   WindowSmoother<kLongTermWindowSize> long_term_highpri_bytes_sampler_;
   WindowSmoother<kRecentSmoothWindowSize, kRecentSmoothWindowSize>
       limit_bytes_sampler_;
+  std::atomic<bool> pace_up_request_;
   int32_t ratio_delta_;
 };
 


### PR DESCRIPTION
Signed-off-by: tabokie <xy.tao@outlook.com>

Proactively pace up auto-tuned rate limiter when LSM shape (L0-count/pending-bytes) is close to trigger write stall.

Mitigate tikv/tikv#8962