### PR TITLE
table_cache: Generate unique ID based on db instance, file number (#205)

### DIFF
--- a/db/table_cache.h
+++ b/db/table_cache.h
@@ -193,6 +193,9 @@ class TableCache {
   std::string row_cache_id_;
   bool immortal_tables_;
   BlockCacheTracer* const block_cache_tracer_;
+  const uint64_t cache_id_;
+
+  static std::atomic<uint64_t> cache_id_alloc;
 };
 
 }  // namespace rocksdb

--- a/env/env_encryption.cc
+++ b/env/env_encryption.cc
@@ -173,6 +173,10 @@ class EncryptedRandomAccessFile : public RandomAccessFile {
     return file_->GetUniqueId(id, max_size);
   };
 
+  void SetUniqueId(std::string unique_id) override {
+    file_->SetUniqueId(unique_id);
+  }
+
   void Hint(AccessPattern pattern) override { file_->Hint(pattern); }
 
   // Indicates the upper layers if the current RandomAccessFile implementation

--- a/env/io_posix.h
+++ b/env/io_posix.h
@@ -50,11 +50,6 @@ static Status IOError(const std::string& context, const std::string& file_name,
   }
 }
 
-class PosixHelper {
- public:
-  static size_t GetUniqueIdFromFile(int fd, char* id, size_t max_size);
-};
-
 class PosixSequentialFile : public SequentialFile {
  private:
   std::string filename_;
@@ -96,9 +91,6 @@ class PosixRandomAccessFile : public RandomAccessFile {
 
   virtual Status Prefetch(uint64_t offset, size_t n) override;
 
-#if defined(OS_LINUX) || defined(OS_MACOSX) || defined(OS_AIX)
-  virtual size_t GetUniqueId(char* id, size_t max_size) const override;
-#endif
   virtual void Hint(AccessPattern pattern) override;
   virtual Status InvalidateCache(size_t offset, size_t length) override;
   virtual bool use_direct_io() const override { return use_direct_io_; }
@@ -150,9 +142,6 @@ class PosixWritableFile : public WritableFile {
   virtual Status Allocate(uint64_t offset, uint64_t len) override;
 #endif
   virtual Status RangeSync(uint64_t offset, uint64_t nbytes) override;
-#ifdef OS_LINUX
-  virtual size_t GetUniqueId(char* id, size_t max_size) const override;
-#endif
 };
 
 // mmap() based random-access

--- a/port/win/io_win.h
+++ b/port/win/io_win.h
@@ -56,8 +56,6 @@ Status fallocate(const std::string& filename, HANDLE hFile, uint64_t to_size);
 
 Status ftruncate(const std::string& filename, HANDLE hFile, uint64_t toSize);
 
-size_t GetUniqueIdFromFile(HANDLE hFile, char* id, size_t max_size);
-
 class WinFileData {
  protected:
   const std::string filename_;
@@ -143,8 +141,6 @@ class WinMmapReadableFile : private WinFileData, public RandomAccessFile {
                       char* scratch) const override;
 
   virtual Status InvalidateCache(size_t offset, size_t length) override;
-
-  virtual size_t GetUniqueId(char* id, size_t max_size) const override;
 };
 
 // We preallocate and use memcpy to append new
@@ -225,8 +221,6 @@ class WinMmapFile : private WinFileData, public WritableFile {
   virtual Status InvalidateCache(size_t offset, size_t length) override;
 
   virtual Status Allocate(uint64_t offset, uint64_t len) override;
-
-  virtual size_t GetUniqueId(char* id, size_t max_size) const override;
 };
 
 class WinRandomAccessImpl {
@@ -268,8 +262,6 @@ class WinRandomAccessFile
 
   virtual Status Read(uint64_t offset, size_t n, Slice* result,
                       char* scratch) const override;
-
-  virtual size_t GetUniqueId(char* id, size_t max_size) const override;
 
   virtual bool use_direct_io() const override { return WinFileData::use_direct_io(); }
 
@@ -374,8 +366,6 @@ class WinWritableFile : private WinFileData,
   virtual uint64_t GetFileSize() override;
 
   virtual Status Allocate(uint64_t offset, uint64_t len) override;
-
-  virtual size_t GetUniqueId(char* id, size_t max_size) const override;
 };
 
 class WinRandomRWFile : private WinFileData,
@@ -437,8 +427,6 @@ class WinDirectory : public Directory {
     ::CloseHandle(handle_);
   }
   virtual Status Fsync() override;
-
-  size_t GetUniqueId(char* id, size_t max_size) const override;
 };
 
 class WinFileLock : public FileLock {

--- a/util/file_reader_writer.cc
+++ b/util/file_reader_writer.cc
@@ -695,6 +695,10 @@ class ReadaheadRandomAccessFile : public RandomAccessFile {
    return file_->GetUniqueId(id, max_size);
  }
 
+ void SetUniqueId(std::string unique_id) override {
+   file_->SetUniqueId(unique_id);
+ }
+
  void Hint(AccessPattern pattern) override { file_->Hint(pattern); }
 
  Status InvalidateCache(size_t offset, size_t length) override {

--- a/utilities/env_mirror.cc
+++ b/utilities/env_mirror.cc
@@ -92,6 +92,10 @@ class RandomAccessFileMirror : public RandomAccessFile {
     // NOTE: not verified
     return a_->GetUniqueId(id, max_size);
   }
+
+  void SetUniqueId(std::string unique_id) override {
+    a_->SetUniqueId(unique_id);
+  }
 };
 
 class WritableFileMirror : public WritableFile {


### PR DESCRIPTION
* table_cache: Generate unique ID based on db instance, file number

This change updates the cache key prefix for SST files from relying
on the inode generation number to using a passed-in unique ID. This
ID is composed of a table-cache-specific random ID, as well as the
number of the SST. This should resolve issues around cache collisions
between two different SS tables that happened to have the same
generation number.

Signed-off-by: Connor1996 <zbk602423539@gmail.com>
Co-authored-by: Bilal Akhtar <bilal@cockroachlabs.com>