### PR TITLE
always count level0 compaction in pending bytes

### DIFF
--- a/db/version_set.cc
+++ b/db/version_set.cc
@@ -2176,16 +2176,8 @@ void VersionStorageInfo::EstimateCompactionBytesNeeded(
     level_size += f->fd.GetFileSize();
   }
   // Level 0
-  bool level0_compact_triggered = false;
-  if (static_cast<int>(files_[0].size()) >=
-          mutable_cf_options.level0_file_num_compaction_trigger ||
-      level_size >= mutable_cf_options.max_bytes_for_level_base) {
-    level0_compact_triggered = true;
-    estimated_compaction_needed_bytes_ = level_size;
-    bytes_compact_to_next_level = level_size;
-  } else {
-    estimated_compaction_needed_bytes_ = 0;
-  }
+  estimated_compaction_needed_bytes_ = level_size;
+  bytes_compact_to_next_level = level_size;
 
   // Level 1 and up.
   uint64_t bytes_next_level = 0;
@@ -2206,8 +2198,8 @@ void VersionStorageInfo::EstimateCompactionBytesNeeded(
         level_size += f->fd.GetFileSize();
       }
     }
-    if (level == base_level() && level0_compact_triggered) {
-      // Add base level size to compaction if level0 compaction triggered.
+    if (level == base_level()) {
+      // level0 compaction
       estimated_compaction_needed_bytes_ += level_size;
     }
     // Add size added by previous compaction


### PR DESCRIPTION
Signed-off-by: tabokie <xy.tao@outlook.com>

The amount of data in Level0 is relatively small, but capable of triggering cascaded compactions. I suggest we consider the case where Level0 is fully compacted to BaseLevel to avoid zigzag pattern like the graphic below.

![image](https://user-images.githubusercontent.com/27005812/100336768-88a4a180-3011-11eb-9555-9ed056293454.png)

FYI, pebble is already doing this (https://github.com/cockroachdb/pebble/blob/master/docs/rocksdb.md#flush-and-compaction-pacing)
