### PR TITLE
Atomize Rename operation when encryption is enabled

### DIFF
--- a/db/db_test_util.cc
+++ b/db/db_test_util.cc
@@ -14,14 +14,6 @@
 
 namespace rocksdb {
 
-#ifdef OPENSSL
-const std::string TestKeyManager::default_key =
-    "\x12\x34\x56\x78\x12\x34\x56\x78\x12\x34\x56\x78\x12\x34\x56\x78\x12\x34"
-    "\x56\x78\x12\x34\x56\x78";
-const std::string TestKeyManager::default_iv =
-    "\xaa\xbb\xcc\xdd\xaa\xbb\xcc\xdd\xaa\xbb\xcc\xdd\xaa\xbb\xcc\xdd";
-#endif
-
 // Special Env used to delay background operations
 
 SpecialEnv::SpecialEnv(Env* base)

--- a/db/db_test_util.h
+++ b/db/db_test_util.h
@@ -56,38 +56,6 @@
 
 namespace rocksdb {
 
-//TODO(yiwu): Use InMemoryKeyManager instead for tests.
-#ifdef OPENSSL
-class TestKeyManager : public encryption::KeyManager {
- public:
-  virtual ~TestKeyManager() = default;
-
-  static const std::string default_key;
-  static const std::string default_iv;
-
-  Status GetFile(const std::string& /*fname*/,
-                 encryption::FileEncryptionInfo* file_info) override {
-    file_info->method = encryption::EncryptionMethod::kAES192_CTR;
-    file_info->key = default_key;
-    file_info->iv = default_iv;
-    return Status::OK();
-  }
-
-  Status NewFile(const std::string& /*fname*/,
-                 encryption::FileEncryptionInfo* file_info) override {
-    file_info->method = encryption::EncryptionMethod::kAES192_CTR;
-    file_info->key = default_key;
-    file_info->iv = default_iv;
-    return Status::OK();
-  }
-
-  Status DeleteFile(const std::string&) override { return Status::OK(); }
-  Status LinkFile(const std::string&, const std::string&) override {
-    return Status::OK();
-  }
-};
-#endif
-
 namespace anon {
 class AtomicCounter {
  public:

--- a/encryption/encryption.cc
+++ b/encryption/encryption.cc
@@ -434,8 +434,8 @@ Status KeyManagedEncryptedEnv::DeleteFile(const std::string& fname) {
 Status KeyManagedEncryptedEnv::LinkFile(const std::string& src_fname,
                                         const std::string& dst_fname) {
   if (ShouldSkipEncryption(dst_fname)) {
-    Status s = target()->LinkFile(src_fname, dst_fname);
     assert(ShouldSkipEncryption(src_fname));
+    Status s = target()->LinkFile(src_fname, dst_fname);
     return s;
   } else {
     assert(!ShouldSkipEncryption(src_fname));
@@ -456,12 +456,8 @@ Status KeyManagedEncryptedEnv::LinkFile(const std::string& src_fname,
 Status KeyManagedEncryptedEnv::RenameFile(const std::string& src_fname,
                                           const std::string& dst_fname) {
   if (ShouldSkipEncryption(dst_fname)) {
-    Status s = target()->RenameFile(src_fname, dst_fname);
-    if (!s.ok()) {
-      return s;
-    }
     assert(ShouldSkipEncryption(src_fname));
-    return s;
+    return target()->RenameFile(src_fname, dst_fname);
   } else {
     assert(!ShouldSkipEncryption(src_fname));
   }

--- a/encryption/encryption.cc
+++ b/encryption/encryption.cc
@@ -443,12 +443,13 @@ Status KeyManagedEncryptedEnv::RenameFile(const std::string& src_fname,
   // In order to ensure that the key manager does not have this dst_fname
   // information, it may exist in the file system, rename will rewrite
   // the file, so this is acceptable.
-  Status delete_status __attribute__((__unused__)) =
-      key_manager_->DeleteFile(dst_fname);
-  assert(delete_status.ok());
+  Status s = = key_manager_->DeleteFile(dst_fname);
+  if (!s.ok()) {
+    return s;
+  }
   // Link(copy)File instead of RenameFile to avoid losing src_fname info when
   // failed to rename the src_fname in the file system.
-  Status s = key_manager_->LinkFile(src_fname, dst_fname);
+  s = key_manager_->LinkFile(src_fname, dst_fname);
   if (!s.ok()) {
     return s;
   }
@@ -456,7 +457,8 @@ Status KeyManagedEncryptedEnv::RenameFile(const std::string& src_fname,
   if (s.ok()) {
     s = key_manager_->DeleteFile(src_fname);
   } else {
-    delete_status = key_manager_->DeleteFile(dst_fname);
+    Status delete_status __attribute__((__unused__)) =
+        key_manager_->DeleteFile(dst_fname);
     assert(delete_status.ok());
   }
   return s;

--- a/encryption/encryption.cc
+++ b/encryption/encryption.cc
@@ -443,6 +443,12 @@ Status KeyManagedEncryptedEnv::DeleteFile(const std::string& fname) {
 
 Status KeyManagedEncryptedEnv::LinkFile(const std::string& src_fname,
                                         const std::string& dst_fname) {
+  if (skip_encryption(dst_fname)) {
+    Status s = target()->LinkFile(src_fname, dst_fname);
+    if (!s.ok()) {
+      return s;
+    }
+  }
   Status s = key_manager_->LinkFile(src_fname, dst_fname);
   if (!s.ok()) {
     return s;
@@ -458,6 +464,14 @@ Status KeyManagedEncryptedEnv::LinkFile(const std::string& src_fname,
 
 Status KeyManagedEncryptedEnv::RenameFile(const std::string& src_fname,
                                           const std::string& dst_fname) {
+  if (skip_encryption(dst_fname)) {
+    Status s = target()->RenameFile(src_fname, dst_fname);
+    if (!s.ok()) {
+      return s;
+    }
+    s = key_manager_->DeleteFile(src_fname);
+    return s;
+  }
   // Link(copy)File instead of RenameFile to avoid losing src_fname info when
   // failed to rename the src_fname in the file system.
   Status s = key_manager_->LinkFile(src_fname, dst_fname);

--- a/encryption/encryption.cc
+++ b/encryption/encryption.cc
@@ -435,7 +435,10 @@ Status KeyManagedEncryptedEnv::LinkFile(const std::string& src_fname,
                                         const std::string& dst_fname) {
   if (ShouldSkipEncryption(dst_fname)) {
     Status s = target()->LinkFile(src_fname, dst_fname);
+    assert(ShouldSkipEncryption(src_fname));
     return s;
+  } else {
+    assert(!ShouldSkipEncryption(src_fname));
   }
   Status s = key_manager_->LinkFile(src_fname, dst_fname);
   if (!s.ok()) {
@@ -459,6 +462,8 @@ Status KeyManagedEncryptedEnv::RenameFile(const std::string& src_fname,
     }
     assert(ShouldSkipEncryption(src_fname));
     return s;
+  } else {
+    assert(!ShouldSkipEncryption(src_fname));
   }
   // Link(copy)File instead of RenameFile to avoid losing src_fname info when
   // failed to rename the src_fname in the file system.

--- a/encryption/encryption.cc
+++ b/encryption/encryption.cc
@@ -457,7 +457,7 @@ Status KeyManagedEncryptedEnv::RenameFile(const std::string& src_fname,
     if (!s.ok()) {
       return s;
     }
-    s = key_manager_->DeleteFile(src_fname);
+    assert(ShouldSkipEncryption(src_fname));
     return s;
   }
   // Link(copy)File instead of RenameFile to avoid losing src_fname info when

--- a/encryption/encryption.cc
+++ b/encryption/encryption.cc
@@ -443,7 +443,7 @@ Status KeyManagedEncryptedEnv::RenameFile(const std::string& src_fname,
   // In order to ensure that the key manager does not have this dst_fname
   // information, it may exist in the file system, rename will rewrite
   // the file, so this is acceptable.
-  Status s = = key_manager_->DeleteFile(dst_fname);
+  Status s = key_manager_->DeleteFile(dst_fname);
   if (!s.ok()) {
     return s;
   }

--- a/env/env_basic_test.cc
+++ b/env/env_basic_test.cc
@@ -124,21 +124,19 @@ class DummyFileSystemInspector : public FileSystemInspector {
   size_t refill_bytes_;
 };
 
-static std::unique_ptr<Env> inspected_fs_env(
+static std::unique_ptr<Env> fs_inspected_env(
     NewFileSystemInspectedEnv(new NormalizingEnvWrapper(Env::Default()),
                               std::make_shared<DummyFileSystemInspector>(1)));
 INSTANTIATE_TEST_CASE_P(FileSystemInspectedEnv, EnvBasicTestWithParam,
-                        ::testing::Values(inspected_fs_env.get()));
+                        ::testing::Values(fs_inspected_env.get()));
 
-#ifdef ROCKSDB_LITE
 #ifdef OPENSSL
-static std::unique_ptr<Env> inspected_encrypt_env(
+static std::unique_ptr<Env> key_managed_encrypted_env(
     NewKeyManagedEncryptedEnv(new NormalizingEnvWrapper(Env::Default()),
                               std::make_shared<KeyManager>(TestKeyManager)));
 INSTANTIATE_TEST_CASE_P(FileSystemInspectedEnv, EnvBasicTestWithParam,
-                        ::testing::Values(inspected_encrypt_env.get()));
-#endif
-#endif
+                        ::testing::Values(key_managed_encrypted_env.get()));
+#endif  // OPENSSL
 
 namespace {
 

--- a/env/env_basic_test.cc
+++ b/env/env_basic_test.cc
@@ -4,10 +4,10 @@
 //
 // Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
 
+#include <algorithm>
 #include <memory>
 #include <string>
 #include <vector>
-#include <algorithm>
 
 #include "env/mock_env.h"
 #include "rocksdb/env.h"
@@ -124,11 +124,21 @@ class DummyFileSystemInspector : public FileSystemInspector {
   size_t refill_bytes_;
 };
 
-static std::unique_ptr<Env> inspected_env(
+static std::unique_ptr<Env> inspected_fs_env(
     NewFileSystemInspectedEnv(new NormalizingEnvWrapper(Env::Default()),
                               std::make_shared<DummyFileSystemInspector>(1)));
 INSTANTIATE_TEST_CASE_P(FileSystemInspectedEnv, EnvBasicTestWithParam,
-                        ::testing::Values(inspected_env.get()));
+                        ::testing::Values(inspected_fs_env.get()));
+
+#ifdef ROCKSDB_LITE
+#ifdef OPENSSL
+static std::unique_ptr<Env> inspected_encrypt_env(
+    NewKeyManagedEncryptedEnv(new NormalizingEnvWrapper(Env::Default()),
+                              std::make_shared<KeyManager>(TestKeyManager)));
+INSTANTIATE_TEST_CASE_P(FileSystemInspectedEnv, EnvBasicTestWithParam,
+                        ::testing::Values(inspected_encrypt_env.get()));
+#endif
+#endif
 
 namespace {
 
@@ -321,7 +331,7 @@ TEST_P(EnvBasicTestWithParam, LargeWrite) {
     read += result.size();
   }
   ASSERT_TRUE(write_data == read_data);
-  delete [] scratch;
+  delete[] scratch;
 }
 
 TEST_P(EnvMoreTestWithParam, GetModTime) {

--- a/env/env_basic_test.cc
+++ b/env/env_basic_test.cc
@@ -9,6 +9,7 @@
 #include <string>
 #include <vector>
 
+#include "db/db_test_util.h"
 #include "env/mock_env.h"
 #include "rocksdb/env.h"
 #include "rocksdb/env_inspected.h"
@@ -131,15 +132,14 @@ INSTANTIATE_TEST_CASE_P(FileSystemInspectedEnv, EnvBasicTestWithParam,
                         ::testing::Values(fs_inspected_env.get()));
 
 #ifdef OPENSSL
-static std::unique_ptr<Env> key_managed_encrypted_env(
-    NewKeyManagedEncryptedEnv(new NormalizingEnvWrapper(Env::Default()),
-                              std::make_shared<KeyManager>(TestKeyManager)));
-INSTANTIATE_TEST_CASE_P(FileSystemInspectedEnv, EnvBasicTestWithParam,
+std::shared_ptr<encryption::KeyManager> key_manager(new TestKeyManager);
+static std::unique_ptr<Env> key_managed_encrypted_env(NewKeyManagedEncryptedEnv(
+    new NormalizingEnvWrapper(Env::Default()), key_manager));
+INSTANTIATE_TEST_CASE_P(KeyManagedEncryptedEnv, EnvBasicTestWithParam,
                         ::testing::Values(key_managed_encrypted_env.get()));
 #endif  // OPENSSL
 
 namespace {
-
 // Returns a vector of 0 or 1 Env*, depending whether an Env is registered for
 // TEST_ENV_URI.
 //

--- a/file/filename.cc
+++ b/file/filename.cc
@@ -24,13 +24,13 @@ namespace rocksdb {
 static const std::string kRocksDbTFileExt = "sst";
 static const std::string kLevelDbTFileExt = "ldb";
 static const std::string kRocksDBBlobFileExt = "blob";
-static const std::string kEncryptionSkipSuffix  = "CURRENT";
+static const std::string kEncryptionSkipName  = "CURRENT";
 
 bool ShouldSkipEncryption(const std::string& fname) {
-  size_t check_length = kEncryptionSkipSuffix.length();
+  size_t check_length = kEncryptionSkipName.length();
   if (fname.length() >= check_length &&
       !fname.compare(fname.length() - check_length, check_length,
-                     kEncryptionSkipSuffix)) {
+                     kEncryptionSkipName)) {
     return true;
   } else {
     return false;
@@ -376,7 +376,8 @@ Status SetCurrentFile(Env* env, const std::string& dbname,
   Slice contents = manifest;
   assert(contents.starts_with(dbname + "/"));
   contents.remove_prefix(dbname.size() + 1);
-  std::string tmp = TempFileName(dbname, descriptor_number);
+  std::string tmp =
+      TempFileName(dbname, descriptor_number) + "." + kEncryptionSkipName;
   Status s = WriteStringToFile(env, contents.ToString() + "\n", tmp, true);
   if (s.ok()) {
     TEST_KILL_RANDOM("SetCurrentFile:0", rocksdb_kill_odds * REDUCE_ODDS2);

--- a/file/filename.cc
+++ b/file/filename.cc
@@ -24,6 +24,18 @@ namespace rocksdb {
 static const std::string kRocksDbTFileExt = "sst";
 static const std::string kLevelDbTFileExt = "ldb";
 static const std::string kRocksDBBlobFileExt = "blob";
+static const std::string kEncryptionSkipSuffix  = "CURRENT";
+
+bool ShouldSkipEncryption(const std::string& fname) {
+  size_t check_length = kEncryptionSkipSuffix.length();
+  if (fname.length() >= check_length &&
+      !fname.compare(fname.length() - check_length, check_length,
+                     kEncryptionSkipSuffix)) {
+    return true;
+  } else {
+    return false;
+  }
+}
 
 // Given a path, flatten the path name by replacing all chars not in
 // {[0-9,a-z,A-Z,-,_,.]} with _. And append '_LOG\0' at the end.

--- a/file/filename.h
+++ b/file/filename.h
@@ -42,6 +42,9 @@ enum FileType {
   kBlobFile
 };
 
+// For some files, we don't require them to be encrypted.
+extern bool ShouldSkipEncryption(const std::string& fname);
+
 // Return the name of the log file with the specified number
 // in the db named by "dbname".  The result will be prefixed with
 // "dbname".

--- a/file/filename.h
+++ b/file/filename.h
@@ -42,7 +42,8 @@ enum FileType {
   kBlobFile
 };
 
-// For some files, we don't require them to be encrypted.
+// Some non-sensitive files are not encrypted to preserve atomicity of file
+// operations.
 extern bool ShouldSkipEncryption(const std::string& fname);
 
 // Return the name of the log file with the specified number

--- a/test_util/testutil.cc
+++ b/test_util/testutil.cc
@@ -19,6 +19,15 @@
 #include "util/file_reader_writer.h"
 
 namespace rocksdb {
+
+#ifdef OPENSSL
+const std::string TestKeyManager::default_key =
+    "\x12\x34\x56\x78\x12\x34\x56\x78\x12\x34\x56\x78\x12\x34\x56\x78\x12\x34"
+    "\x56\x78\x12\x34\x56\x78";
+const std::string TestKeyManager::default_iv =
+    "\xaa\xbb\xcc\xdd\xaa\xbb\xcc\xdd\xaa\xbb\xcc\xdd\xaa\xbb\xcc\xdd";
+#endif
+
 namespace test {
 
 const uint32_t kDefaultFormatVersion = BlockBasedTableOptions().format_version;

--- a/test_util/testutil.cc
+++ b/test_util/testutil.cc
@@ -21,11 +21,13 @@
 namespace rocksdb {
 
 #ifdef OPENSSL
+#ifndef ROCKSDB_LITE
 const std::string TestKeyManager::default_key =
     "\x12\x34\x56\x78\x12\x34\x56\x78\x12\x34\x56\x78\x12\x34\x56\x78\x12\x34"
     "\x56\x78\x12\x34\x56\x78";
 const std::string TestKeyManager::default_iv =
     "\xaa\xbb\xcc\xdd\xaa\xbb\xcc\xdd\xaa\xbb\xcc\xdd\xaa\xbb\xcc\xdd";
+#endif
 #endif
 
 namespace test {

--- a/test_util/testutil.h
+++ b/test_util/testutil.h
@@ -32,6 +32,7 @@ namespace rocksdb {
 
 // TODO(yiwu): Use InMemoryKeyManager instead for tests.
 #ifdef OPENSSL
+#ifndef ROCKSDB_LITE
 class TestKeyManager : public encryption::KeyManager {
  public:
   virtual ~TestKeyManager() = default;
@@ -60,6 +61,7 @@ class TestKeyManager : public encryption::KeyManager {
     return Status::OK();
   }
 };
+#endif
 #endif
 
 class SequentialFile;

--- a/test_util/testutil.h
+++ b/test_util/testutil.h
@@ -48,7 +48,6 @@ class TestKeyManager : public encryption::KeyManager {
     } else {
       file_info->method = encryption::EncryptionMethod::kAES192_CTR;
     }
-    file_info->method = encryption::EncryptionMethod::kAES192_CTR;
     file_info->key = default_key;
     file_info->iv = default_iv;
     return Status::OK();

--- a/test_util/testutil.h
+++ b/test_util/testutil.h
@@ -27,6 +27,7 @@
 #include "table/plain/plain_table_factory.h"
 #include "util/mutexlock.h"
 #include "util/random.h"
+#include "file/filename.h"
 
 namespace rocksdb {
 
@@ -40,8 +41,13 @@ class TestKeyManager : public encryption::KeyManager {
   static const std::string default_key;
   static const std::string default_iv;
 
-  Status GetFile(const std::string& /*fname*/,
+  Status GetFile(const std::string& fname,
                  encryption::FileEncryptionInfo* file_info) override {
+    if (ShouldSkipEncryption(fname)) {
+      file_info->method = encryption::EncryptionMethod::kPlaintext;
+    } else {
+      file_info->method = encryption::EncryptionMethod::kAES192_CTR;
+    }
     file_info->method = encryption::EncryptionMethod::kAES192_CTR;
     file_info->key = default_key;
     file_info->iv = default_iv;


### PR DESCRIPTION
https://github.com/tikv/rocksdb/pull/222 used `LinkFile` instead of `RenameFile` api of key manager. But `LinkFile` needs check the dst file information, in `RenameFile` logic, we don't care about that. So just skip encryption for current file.

Signed-off-by: Xintao <hunterlxt@live.com>