### PR TITLE
Do not tune down write-amp based rate limit when flush flow decreases

### DIFF
--- a/utilities/rate_limiters/write_amp_based_rate_limiter.cc
+++ b/utilities/rate_limiters/write_amp_based_rate_limiter.cc
@@ -317,11 +317,10 @@ int64_t WriteAmpBasedRateLimiter::CalculateRefillBytesPerPeriod(
 
 // The core function used to dynamically adjust the compaction rate limit,
 // called **at most** once every `kSecondsPerTune`.
-// A write amplification ratio is calculated based on history samples of
-// compaction and flush flow, then it is used to deduce the appropriate
-// threshold before next tune. This algorithm excels by taking into account
-// the limiter's inability to estimate the pressure of pending compactions,
-// and the possibility of foreground write fluctuation.
+// I/O throughput threshold is automatically tuned based on history samples of
+// compaction and flush flow. This algorithm excels by taking into account the
+// limiter's inability to estimate the pressure of pending compactions, and the
+// possibility of foreground write fluctuation.
 Status WriteAmpBasedRateLimiter::Tune() {
   // computed rate limit will be larger than 10MB/s
   const int64_t kMinBytesPerSec = 10 << 20;

--- a/utilities/rate_limiters/write_amp_based_rate_limiter.cc
+++ b/utilities/rate_limiters/write_amp_based_rate_limiter.cc
@@ -353,8 +353,9 @@ Status WriteAmpBasedRateLimiter::Tune() {
       static_cast<int32_t>(
           bytes_sampler_.GetFullValue() * 10 /
           std::max(highpri_bytes_sampler_.GetFullValue(), kHighBytesLower)));
-  // Only adjust threshold when foreground writes (flush flow) increases rather
-  // than decreases.
+  // Only adjust threshold when foreground write (flush) flow increases,
+  // because decreasement could also be caused by manual flow control at
+  // application level to alleviate background pressure.
   new_bytes_per_sec = std::max(
       new_bytes_per_sec,
       ratio *


### PR DESCRIPTION
Because foreground writes can be proactively restrained when compactions lag behind, added a minor algorithm change that avoids tuning down rate limit when foreground writes (flush flow) decrease. This will not affect the overall performance of `WriteAmpBasedRateLimiter`.