### PR TITLE
Fix compilation when jemalloc is enabled on clang 

### DIFF
--- a/port/jemalloc_helper.h
+++ b/port/jemalloc_helper.h
@@ -40,23 +40,34 @@ static inline bool HasJemalloc() { return true; }
 
 // Declare non-standard jemalloc APIs as weak symbols. We can null-check these
 // symbols to detect whether jemalloc is linked with the binary.
-extern "C" void* mallocx(size_t, int) __attribute__((__weak__));
-extern "C" void* rallocx(void*, size_t, int) __attribute__((__weak__));
-extern "C" size_t xallocx(void*, size_t, size_t, int) __attribute__((__weak__));
-extern "C" size_t sallocx(const void*, int) __attribute__((__weak__));
-extern "C" void dallocx(void*, int) __attribute__((__weak__));
-extern "C" void sdallocx(void*, size_t, int) __attribute__((__weak__));
-extern "C" size_t nallocx(size_t, int) __attribute__((__weak__));
-extern "C" int mallctl(const char*, void*, size_t*, void*, size_t)
+extern "C" JEMALLOC_ALLOCATOR JEMALLOC_RESTRICT_RETURN void JEMALLOC_NOTHROW *
+mallocx(size_t, int) JEMALLOC_ATTR(malloc) JEMALLOC_ALLOC_SIZE(1)
     __attribute__((__weak__));
-extern "C" int mallctlnametomib(const char*, size_t*, size_t*)
+extern "C" JEMALLOC_ALLOCATOR JEMALLOC_RESTRICT_RETURN void JEMALLOC_NOTHROW *
+rallocx(void *, size_t, int) JEMALLOC_ALLOC_SIZE(2) __attribute__((__weak__));
+extern "C" size_t JEMALLOC_NOTHROW xallocx(void *, size_t, size_t, int)
     __attribute__((__weak__));
-extern "C" int mallctlbymib(const size_t*, size_t, void*, size_t*, void*,
-                            size_t) __attribute__((__weak__));
-extern "C" void malloc_stats_print(void (*)(void*, const char*), void*,
-                                   const char*) __attribute__((__weak__));
-extern "C" size_t malloc_usable_size(JEMALLOC_USABLE_SIZE_CONST void*)
-    JEMALLOC_CXX_THROW __attribute__((__weak__));
+extern "C" size_t JEMALLOC_NOTHROW sallocx(const void *, int)
+    JEMALLOC_ATTR(pure) __attribute__((__weak__));
+extern "C" void JEMALLOC_NOTHROW dallocx(void *, int) __attribute__((__weak__));
+extern "C" void JEMALLOC_NOTHROW sdallocx(void *, size_t, int)
+    __attribute__((__weak__));
+extern "C" size_t JEMALLOC_NOTHROW nallocx(size_t, int) JEMALLOC_ATTR(pure)
+    __attribute__((__weak__));
+extern "C" int JEMALLOC_NOTHROW mallctl(const char *, void *, size_t *, void *,
+                                        size_t) __attribute__((__weak__));
+extern "C" int JEMALLOC_NOTHROW mallctlnametomib(const char *, size_t *,
+                                                 size_t *)
+    __attribute__((__weak__));
+extern "C" int JEMALLOC_NOTHROW mallctlbymib(const size_t *, size_t, void *,
+                                             size_t *, void *, size_t)
+    __attribute__((__weak__));
+extern "C" void JEMALLOC_NOTHROW
+malloc_stats_print(void (*)(void *, const char *), void *, const char *)
+    __attribute__((__weak__));
+extern "C" size_t JEMALLOC_NOTHROW
+malloc_usable_size(JEMALLOC_USABLE_SIZE_CONST void *) JEMALLOC_CXX_THROW
+    __attribute__((__weak__));
 
 // Check if Jemalloc is linked with the binary. Note the main program might be
 // using a different memory allocator even this method return true.


### PR DESCRIPTION
Now it does not compile at my place with clang 11 and 12 if jemalloc is enabled.

```
> CC=clang CXX=clang++ cargo build --features "jemalloc,static_libcpp"
...
  In file included from /home/yilin/Code/rust-rocksdb/librocksdb_sys/rocksdb/db/malloc_stats.cc:16:
  /home/yilin/Code/rust-rocksdb/librocksdb_sys/rocksdb/port/jemalloc_helper.h:43:18: error: 'mallocx' is missing exception specification '__attribute__((nothrow))' [-Werror,-Wmissing-exception-spec]
  extern "C" void* mallocx(size_t, int) __attribute__((__weak__));
                   ^
                                        __attribute__((nothrow))
  /home/yilin/Code/rust-rocksdb/target/debug/build/tikv-jemalloc-sys-bafc6265fb6ded08/out/include/jemalloc/jemalloc.h:385:19: note: expanded from macro 'mallocx'
  #  define mallocx je_mallocx
                    ^
  /home/yilin/Code/rust-rocksdb/target/debug/build/tikv-jemalloc-sys-bafc6265fb6ded08/out/include/jemalloc/jemalloc.h:74:22: note: expanded from macro 'je_mallocx'
  #  define je_mallocx mallocx
                       ^
  /home/yilin/Code/rust-rocksdb/target/debug/build/tikv-jemalloc-sys-bafc6265fb6ded08/out/include/jemalloc/jemalloc.h:245:28: note: previous declaration is here
      void JEMALLOC_NOTHROW       *je_mallocx(size_t size, int flags)
                                   ^
  /home/yilin/Code/rust-rocksdb/target/debug/build/tikv-jemalloc-sys-bafc6265fb6ded08/out/include/jemalloc/jemalloc.h:74:22: note: expanded from macro 'je_mallocx'
  #  define je_mallocx mallocx
                       ^
  In file included from /home/yilin/Code/rust-rocksdb/librocksdb_sys/rocksdb/db/malloc_stats.cc:16:
  /home/yilin/Code/rust-rocksdb/librocksdb_sys/rocksdb/port/jemalloc_helper.h:44:18: error: 'rallocx' is missing exception specification '__attribute__((nothrow))' [-Werror,-Wmissing-exception-spec]
  extern "C" void* rallocx(void*, size_t, int) __attribute__((__weak__));
                   ^
                                               __attribute__((nothrow))
  /home/yilin/Code/rust-rocksdb/target/debug/build/tikv-jemalloc-sys-bafc6265fb6ded08/out/include/jemalloc/jemalloc.h:389:19: note: expanded from macro 'rallocx'
  #  define rallocx je_rallocx
                    ^
  /home/yilin/Code/rust-rocksdb/target/debug/build/tikv-jemalloc-sys-bafc6265fb6ded08/out/include/jemalloc/jemalloc.h:78:22: note: expanded from macro 'je_rallocx'
  #  define je_rallocx rallocx
                       ^
  /home/yilin/Code/rust-rocksdb/target/debug/build/tikv-jemalloc-sys-bafc6265fb6ded08/out/include/jemalloc/jemalloc.h:248:28: note: previous declaration is here
      void JEMALLOC_NOTHROW       *je_rallocx(void *ptr, size_t size,
                                   ^
  /home/yilin/Code/rust-rocksdb/target/debug/build/tikv-jemalloc-sys-bafc6265fb6ded08/out/include/jemalloc/jemalloc.h:78:22: note: expanded from macro 'je_rallocx'
  #  define je_rallocx rallocx
                       ^
  In file included from /home/yilin/Code/rust-rocksdb/librocksdb_sys/rocksdb/db/malloc_stats.cc:16:
  /home/yilin/Code/rust-rocksdb/librocksdb_sys/rocksdb/port/jemalloc_helper.h:45:19: error: 'xallocx' is missing exception specification '__attribute__((nothrow))' [-Werror,-Wmissing-exception-spec]
  extern "C" size_t xallocx(void*, size_t, size_t, int) __attribute__((__weak__));
                    ^
                                                        __attribute__((nothrow))
  /home/yilin/Code/rust-rocksdb/target/debug/build/tikv-jemalloc-sys-bafc6265fb6ded08/out/include/jemalloc/jemalloc.h:393:19: note: expanded from macro 'xallocx'
  #  define xallocx je_xallocx
                    ^
  /home/yilin/Code/rust-rocksdb/target/debug/build/tikv-jemalloc-sys-bafc6265fb6ded08/out/include/jemalloc/jemalloc.h:82:22: note: expanded from macro 'je_xallocx'
  #  define je_xallocx xallocx
                       ^
  /home/yilin/Code/rust-rocksdb/target/debug/build/tikv-jemalloc-sys-bafc6265fb6ded08/out/include/jemalloc/jemalloc.h:250:41: note: previous declaration is here
  JEMALLOC_EXPORT size_t JEMALLOC_NOTHROW je_xallocx(void *ptr, size_t size,
                                          ^
  /home/yilin/Code/rust-rocksdb/target/debug/build/tikv-jemalloc-sys-bafc6265fb6ded08/out/include/jemalloc/jemalloc.h:82:22: note: expanded from macro 'je_xallocx'
  #  define je_xallocx xallocx
                       ^
  In file included from /home/yilin/Code/rust-rocksdb/librocksdb_sys/rocksdb/db/malloc_stats.cc:16:
  /home/yilin/Code/rust-rocksdb/librocksdb_sys/rocksdb/port/jemalloc_helper.h:46:19: error: 'sallocx' is missing exception specification '__attribute__((nothrow))' [-Werror,-Wmissing-exception-spec]
  extern "C" size_t sallocx(const void*, int) __attribute__((__weak__));
                    ^
                                              __attribute__((nothrow))
  /home/yilin/Code/rust-rocksdb/target/debug/build/tikv-jemalloc-sys-bafc6265fb6ded08/out/include/jemalloc/jemalloc.h:391:19: note: expanded from macro 'sallocx'
  #  define sallocx je_sallocx
                    ^
  /home/yilin/Code/rust-rocksdb/target/debug/build/tikv-jemalloc-sys-bafc6265fb6ded08/out/include/jemalloc/jemalloc.h:80:22: note: expanded from macro 'je_sallocx'
  #  define je_sallocx sallocx
                       ^
  /home/yilin/Code/rust-rocksdb/target/debug/build/tikv-jemalloc-sys-bafc6265fb6ded08/out/include/jemalloc/jemalloc.h:252:41: note: previous declaration is here
  JEMALLOC_EXPORT size_t JEMALLOC_NOTHROW je_sallocx(const void *ptr,
                                          ^
  /home/yilin/Code/rust-rocksdb/target/debug/build/tikv-jemalloc-sys-bafc6265fb6ded08/out/include/jemalloc/jemalloc.h:80:22: note: expanded from macro 'je_sallocx'
  #  define je_sallocx sallocx
                       ^
  In file included from /home/yilin/Code/rust-rocksdb/librocksdb_sys/rocksdb/db/malloc_stats.cc:16:
  /home/yilin/Code/rust-rocksdb/librocksdb_sys/rocksdb/port/jemalloc_helper.h:47:17: error: 'dallocx' is missing exception specification '__attribute__((nothrow))' [-Werror,-Wmissing-exception-spec]
  extern "C" void dallocx(void*, int) __attribute__((__weak__));
                  ^
                                      __attribute__((nothrow))
  /home/yilin/Code/rust-rocksdb/target/debug/build/tikv-jemalloc-sys-bafc6265fb6ded08/out/include/jemalloc/jemalloc.h:375:19: note: expanded from macro 'dallocx'
  #  define dallocx je_dallocx
                    ^
  /home/yilin/Code/rust-rocksdb/target/debug/build/tikv-jemalloc-sys-bafc6265fb6ded08/out/include/jemalloc/jemalloc.h:64:22: note: expanded from macro 'je_dallocx'
  #  define je_dallocx dallocx
                       ^
  /home/yilin/Code/rust-rocksdb/target/debug/build/tikv-jemalloc-sys-bafc6265fb6ded08/out/include/jemalloc/jemalloc.h:254:39: note: previous declaration is here
  JEMALLOC_EXPORT void JEMALLOC_NOTHROW   je_dallocx(void *ptr, int flags);
                                          ^
  /home/yilin/Code/rust-rocksdb/target/debug/build/tikv-jemalloc-sys-bafc6265fb6ded08/out/include/jemalloc/jemalloc.h:64:22: note: expanded from macro 'je_dallocx'
  #  define je_dallocx dallocx
                       ^
  In file included from /home/yilin/Code/rust-rocksdb/librocksdb_sys/rocksdb/db/malloc_stats.cc:16:
  /home/yilin/Code/rust-rocksdb/librocksdb_sys/rocksdb/port/jemalloc_helper.h:48:17: error: 'sdallocx' is missing exception specification '__attribute__((nothrow))' [-Werror,-Wmissing-exception-spec]
  extern "C" void sdallocx(void*, size_t, int) __attribute__((__weak__));
                  ^
                                               __attribute__((nothrow))
  /home/yilin/Code/rust-rocksdb/target/debug/build/tikv-jemalloc-sys-bafc6265fb6ded08/out/include/jemalloc/jemalloc.h:392:20: note: expanded from macro 'sdallocx'
  #  define sdallocx je_sdallocx
                     ^
  /home/yilin/Code/rust-rocksdb/target/debug/build/tikv-jemalloc-sys-bafc6265fb6ded08/out/include/jemalloc/jemalloc.h:81:23: note: expanded from macro 'je_sdallocx'
  #  define je_sdallocx sdallocx
                        ^
  /home/yilin/Code/rust-rocksdb/target/debug/build/tikv-jemalloc-sys-bafc6265fb6ded08/out/include/jemalloc/jemalloc.h:255:39: note: previous declaration is here
  JEMALLOC_EXPORT void JEMALLOC_NOTHROW   je_sdallocx(void *ptr, size_t size,
                                          ^
  /home/yilin/Code/rust-rocksdb/target/debug/build/tikv-jemalloc-sys-bafc6265fb6ded08/out/include/jemalloc/jemalloc.h:81:23: note: expanded from macro 'je_sdallocx'
  #  define je_sdallocx sdallocx
                        ^
  In file included from /home/yilin/Code/rust-rocksdb/librocksdb_sys/rocksdb/db/malloc_stats.cc:16:
  /home/yilin/Code/rust-rocksdb/librocksdb_sys/rocksdb/port/jemalloc_helper.h:49:19: error: 'nallocx' is missing exception specification '__attribute__((nothrow))' [-Werror,-Wmissing-exception-spec]
  extern "C" size_t nallocx(size_t, int) __attribute__((__weak__));
                    ^
                                         __attribute__((nothrow))
  /home/yilin/Code/rust-rocksdb/target/debug/build/tikv-jemalloc-sys-bafc6265fb6ded08/out/include/jemalloc/jemalloc.h:387:19: note: expanded from macro 'nallocx'
  #  define nallocx je_nallocx
                    ^
  /home/yilin/Code/rust-rocksdb/target/debug/build/tikv-jemalloc-sys-bafc6265fb6ded08/out/include/jemalloc/jemalloc.h:76:22: note: expanded from macro 'je_nallocx'
  #  define je_nallocx nallocx
                       ^
  /home/yilin/Code/rust-rocksdb/target/debug/build/tikv-jemalloc-sys-bafc6265fb6ded08/out/include/jemalloc/jemalloc.h:257:41: note: previous declaration is here
  JEMALLOC_EXPORT size_t JEMALLOC_NOTHROW je_nallocx(size_t size, int flags)
                                          ^
  /home/yilin/Code/rust-rocksdb/target/debug/build/tikv-jemalloc-sys-bafc6265fb6ded08/out/include/jemalloc/jemalloc.h:76:22: note: expanded from macro 'je_nallocx'
  #  define je_nallocx nallocx
                       ^
  In file included from /home/yilin/Code/rust-rocksdb/librocksdb_sys/rocksdb/db/malloc_stats.cc:16:
  /home/yilin/Code/rust-rocksdb/librocksdb_sys/rocksdb/port/jemalloc_helper.h:50:16: error: 'mallctl' is missing exception specification '__attribute__((nothrow))' [-Werror,-Wmissing-exception-spec]
  extern "C" int mallctl(const char*, void*, size_t*, void*, size_t)
                 ^
                                                                     __attribute__((nothrow))
  /home/yilin/Code/rust-rocksdb/target/debug/build/tikv-jemalloc-sys-bafc6265fb6ded08/out/include/jemalloc/jemalloc.h:377:19: note: expanded from macro 'mallctl'
  #  define mallctl je_mallctl
                    ^
  /home/yilin/Code/rust-rocksdb/target/debug/build/tikv-jemalloc-sys-bafc6265fb6ded08/out/include/jemalloc/jemalloc.h:66:22: note: expanded from macro 'je_mallctl'
  #  define je_mallctl mallctl
                       ^
  /home/yilin/Code/rust-rocksdb/target/debug/build/tikv-jemalloc-sys-bafc6265fb6ded08/out/include/jemalloc/jemalloc.h:260:38: note: previous declaration is here
  JEMALLOC_EXPORT int JEMALLOC_NOTHROW    je_mallctl(const char *name,
                                          ^
  /home/yilin/Code/rust-rocksdb/target/debug/build/tikv-jemalloc-sys-bafc6265fb6ded08/out/include/jemalloc/jemalloc.h:66:22: note: expanded from macro 'je_mallctl'
  #  define je_mallctl mallctl
                       ^
  In file included from /home/yilin/Code/rust-rocksdb/librocksdb_sys/rocksdb/db/malloc_stats.cc:16:
  /home/yilin/Code/rust-rocksdb/librocksdb_sys/rocksdb/port/jemalloc_helper.h:52:16: error: 'mallctlnametomib' is missing exception specification '__attribute__((nothrow))' [-Werror,-Wmissing-exception-spec]
  extern "C" int mallctlnametomib(const char*, size_t*, size_t*)
                 ^
                                                                 __attribute__((nothrow))
  /home/yilin/Code/rust-rocksdb/target/debug/build/tikv-jemalloc-sys-bafc6265fb6ded08/out/include/jemalloc/jemalloc.h:379:28: note: expanded from macro 'mallctlnametomib'
  #  define mallctlnametomib je_mallctlnametomib
                             ^
  /home/yilin/Code/rust-rocksdb/target/debug/build/tikv-jemalloc-sys-bafc6265fb6ded08/out/include/jemalloc/jemalloc.h:68:31: note: expanded from macro 'je_mallctlnametomib'
  #  define je_mallctlnametomib mallctlnametomib
                                ^
  /home/yilin/Code/rust-rocksdb/target/debug/build/tikv-jemalloc-sys-bafc6265fb6ded08/out/include/jemalloc/jemalloc.h:262:38: note: previous declaration is here
  JEMALLOC_EXPORT int JEMALLOC_NOTHROW    je_mallctlnametomib(const char *name,
                                          ^
  /home/yilin/Code/rust-rocksdb/target/debug/build/tikv-jemalloc-sys-bafc6265fb6ded08/out/include/jemalloc/jemalloc.h:68:31: note: expanded from macro 'je_mallctlnametomib'
  #  define je_mallctlnametomib mallctlnametomib
                                ^
  In file included from /home/yilin/Code/rust-rocksdb/librocksdb_sys/rocksdb/db/malloc_stats.cc:16:
  /home/yilin/Code/rust-rocksdb/librocksdb_sys/rocksdb/port/jemalloc_helper.h:54:16: error: 'mallctlbymib' is missing exception specification '__attribute__((nothrow))' [-Werror,-Wmissing-exception-spec]
  extern "C" int mallctlbymib(const size_t*, size_t, void*, size_t*, void*,
                 ^
  /home/yilin/Code/rust-rocksdb/target/debug/build/tikv-jemalloc-sys-bafc6265fb6ded08/out/include/jemalloc/jemalloc.h:378:24: note: expanded from macro 'mallctlbymib'
  #  define mallctlbymib je_mallctlbymib
                         ^
  /home/yilin/Code/rust-rocksdb/target/debug/build/tikv-jemalloc-sys-bafc6265fb6ded08/out/include/jemalloc/jemalloc.h:67:27: note: expanded from macro 'je_mallctlbymib'
  #  define je_mallctlbymib mallctlbymib
                            ^
  /home/yilin/Code/rust-rocksdb/target/debug/build/tikv-jemalloc-sys-bafc6265fb6ded08/out/include/jemalloc/jemalloc.h:264:38: note: previous declaration is here
  JEMALLOC_EXPORT int JEMALLOC_NOTHROW    je_mallctlbymib(const size_t *mib,
                                          ^
  /home/yilin/Code/rust-rocksdb/target/debug/build/tikv-jemalloc-sys-bafc6265fb6ded08/out/include/jemalloc/jemalloc.h:67:27: note: expanded from macro 'je_mallctlbymib'
  #  define je_mallctlbymib mallctlbymib
                            ^
  In file included from /home/yilin/Code/rust-rocksdb/librocksdb_sys/rocksdb/db/malloc_stats.cc:16:
  /home/yilin/Code/rust-rocksdb/librocksdb_sys/rocksdb/port/jemalloc_helper.h:56:17: error: 'malloc_stats_print' is missing exception specification '__attribute__((nothrow))' [-Werror,-Wmissing-exception-spec]
  extern "C" void malloc_stats_print(void (*)(void*, const char*), void*,
                  ^
  /home/yilin/Code/rust-rocksdb/target/debug/build/tikv-jemalloc-sys-bafc6265fb6ded08/out/include/jemalloc/jemalloc.h:383:30: note: expanded from macro 'malloc_stats_print'
  #  define malloc_stats_print je_malloc_stats_print
                               ^
  /home/yilin/Code/rust-rocksdb/target/debug/build/tikv-jemalloc-sys-bafc6265fb6ded08/out/include/jemalloc/jemalloc.h:72:33: note: expanded from macro 'je_malloc_stats_print'
  #  define je_malloc_stats_print malloc_stats_print
                                  ^
  /home/yilin/Code/rust-rocksdb/target/debug/build/tikv-jemalloc-sys-bafc6265fb6ded08/out/include/jemalloc/jemalloc.h:266:39: note: previous declaration is here
  JEMALLOC_EXPORT void JEMALLOC_NOTHROW   je_malloc_stats_print(
                                          ^
  /home/yilin/Code/rust-rocksdb/target/debug/build/tikv-jemalloc-sys-bafc6265fb6ded08/out/include/jemalloc/jemalloc.h:72:33: note: expanded from macro 'je_malloc_stats_print'
  #  define je_malloc_stats_print malloc_stats_print
                                  ^
  11 errors generated.
```

This PR cherry picks an upstream commit https://github.com/facebook/rocksdb/commit/4c336c6912cf8d1c7596526f5b38c7446cae4919 to fix the problem.