### PR TITLE
Defer live file query in FindObsoleteFiles

### DIFF
--- a/db/db_impl/db_impl_files.cc
+++ b/db/db_impl/db_impl_files.cc
@@ -103,7 +103,6 @@ void DBImpl::FindObsoleteFiles(JobContext* job_context, bool force,
   job_context->log_number = MinLogNumberToKeep();
   job_context->prev_log_number = versions_->prev_log_number();
 
-  versions_->AddLiveFiles(&job_context->sst_live);
   if (doing_the_full_scan) {
     InfoLogPrefix info_log_prefix(!immutable_db_options_.db_log_dir.empty(),
                                   dbname_);
@@ -234,6 +233,7 @@ void DBImpl::FindObsoleteFiles(JobContext* job_context, bool force,
   job_context->log_recycle_files.assign(log_recycle_files_.begin(),
                                         log_recycle_files_.end());
   if (job_context->HaveSomethingToDelete()) {
+    versions_->AddLiveFiles(&job_context->sst_live_map, mutex_);
     ++pending_purge_obsolete_files_;
   }
   logs_to_free_.clear();
@@ -303,12 +303,6 @@ void DBImpl::PurgeObsoleteFiles(JobContext& state, bool schedule_only) {
   // FindObsoleteFiles() should've populated this so nonzero
   assert(state.manifest_file_number != 0);
 
-  // Now, convert live list to an unordered map, WITHOUT mutex held;
-  // set is slow.
-  std::unordered_map<uint64_t, const FileDescriptor*> sst_live_map;
-  for (const FileDescriptor& fd : state.sst_live) {
-    sst_live_map[fd.GetNumber()] = &fd;
-  }
   std::unordered_set<uint64_t> log_recycle_files_set(
       state.log_recycle_files.begin(), state.log_recycle_files.end());
 
@@ -407,7 +401,7 @@ void DBImpl::PurgeObsoleteFiles(JobContext& state, bool schedule_only) {
       case kTableFile:
         // If the second condition is not there, this makes
         // DontDeletePendingOutputs fail
-        keep = (sst_live_map.find(number) != sst_live_map.end()) ||
+        keep = (state.sst_live_map.find(number) != state.sst_live_map.end()) ||
                number >= state.min_pending_output;
         if (!keep) {
           files_to_del.insert(number);
@@ -422,7 +416,7 @@ void DBImpl::PurgeObsoleteFiles(JobContext& state, bool schedule_only) {
         //
         // TODO(yhchiang): carefully modify the third condition to safely
         //                 remove the temp options files.
-        keep = (sst_live_map.find(number) != sst_live_map.end()) ||
+        keep = (state.sst_live_map.find(number) != state.sst_live_map.end()) ||
                (number == state.pending_manifest_file_number) ||
                (to_delete.find(kOptionsFileNamePrefix) != std::string::npos);
         break;

--- a/db/file_indexer.cc
+++ b/db/file_indexer.cc
@@ -73,7 +73,7 @@ void FileIndexer::GetNextLevelIndex(const size_t level, const size_t file_index,
 }
 
 void FileIndexer::UpdateIndex(Arena* arena, const size_t num_levels,
-                              std::vector<FileMetaData*>* const files) {
+                              const std::vector<FileMetaData*>* const files) {
   if (files == nullptr) {
     return;
   }

--- a/db/file_indexer.h
+++ b/db/file_indexer.h
@@ -56,7 +56,7 @@ class FileIndexer {
                          int32_t* left_bound, int32_t* right_bound) const;
 
   void UpdateIndex(Arena* arena, const size_t num_levels,
-                   std::vector<FileMetaData*>* const files);
+                   const std::vector<FileMetaData*>* const files);
 
   enum {
     // MSVC version 1800 still does not have constexpr for ::max()

--- a/db/job_context.h
+++ b/db/job_context.h
@@ -140,7 +140,7 @@ struct JobContext {
   std::vector<CandidateFileInfo> full_scan_candidate_files;
 
   // the list of all live sst files that cannot be deleted
-  std::vector<FileDescriptor> sst_live;
+  std::unordered_map<uint64_t, FileDescriptor> sst_live_map;
 
   // a list of sst files that we need to delete
   std::vector<ObsoleteFileInfo> sst_delete_files;

--- a/db/job_context.h
+++ b/db/job_context.h
@@ -139,8 +139,8 @@ struct JobContext {
   // (filled only if we're doing full scan)
   std::vector<CandidateFileInfo> full_scan_candidate_files;
 
-  // the list of all live sst files that cannot be deleted
-  std::unordered_map<uint64_t, FileDescriptor> sst_live_map;
+  // a list of all versions that are holding live files
+  std::vector<Version*> version_live;
 
   // a list of sst files that we need to delete
   std::vector<ObsoleteFileInfo> sst_delete_files;

--- a/db/version_set.cc
+++ b/db/version_set.cc
@@ -5028,9 +5028,11 @@ uint64_t VersionSet::ApproximateSize(Version* v, const FdWithKeyRange& f,
   return result;
 }
 
-void VersionSet::AddLiveFiles(std::unordered_map<uint64_t, FileDescriptor>* live_map, InstrumentedMutex& db_mutex) {
+void VersionSet::AddLiveFiles(
+    std::unordered_map<uint64_t, FileDescriptor>* live_map,
+    InstrumentedMutex& db_mutex) {
   db_mutex.AssertHeld();
-  autovector<Version *> versions;
+  autovector<Version*> versions;
   for (auto cfd : *column_family_set_) {
     if (!cfd->initialized()) {
       continue;
@@ -5056,7 +5058,7 @@ void VersionSet::AddLiveFiles(std::unordered_map<uint64_t, FileDescriptor>* live
 
   db_mutex.Unlock();
 
-  for (auto *v : versions) {
+  for (auto* v : versions) {
     auto& vstorage = v->storage_info_;
     for (int level = 0; level < vstorage.num_levels(); level++) {
       const std::vector<FileMetaData*>& files = vstorage.LevelFiles(level);

--- a/db/version_set.h
+++ b/db/version_set.h
@@ -439,7 +439,7 @@ class VersionStorageInfo {
 
   // List of files per level, files in each level are arranged
   // in increasing order of keys
-  // Only mutatable when !finalized_
+  // This container is only mutatable when !finalized_
   std::vector<FileMetaData*>* files_;
 
   // Level that L0 data should be compacted to. All levels < base_level_ should
@@ -982,9 +982,8 @@ class VersionSet {
       const Compaction* c, RangeDelAggregator* range_del_agg,
       const EnvOptions& env_options_compactions);
 
-  // Add all files listed in any live version to *live.
-  void AddLiveFiles(std::unordered_map<uint64_t, FileDescriptor>* live_map,
-                    InstrumentedMutex& db_mutex);
+  // Ref and list all versions to *live.
+  void ListLiveVersions(std::vector<Version*>* live);
 
   // Return the approximate size of data to be scanned for range [start, end)
   // in levels [start_level, end_level). If end_level == -1 it will search

--- a/db/version_set.h
+++ b/db/version_set.h
@@ -104,7 +104,7 @@ class VersionStorageInfo {
                      bool _force_consistency_checks);
   ~VersionStorageInfo();
 
-  void Reserve(int level, size_t size) { files_[level].reserve(size); }
+  void Reserve(int level, size_t size) { assert(!finalized_); files_[level].reserve(size); }
 
   void AddFile(int level, FileMetaData* f, Logger* info_log = nullptr);
 
@@ -436,6 +436,7 @@ class VersionStorageInfo {
 
   // List of files per level, files in each level are arranged
   // in increasing order of keys
+  // Only mutatable when !finalized_
   std::vector<FileMetaData*>* files_;
 
   // Level that L0 data should be compacted to. All levels < base_level_ should
@@ -979,7 +980,7 @@ class VersionSet {
       const EnvOptions& env_options_compactions);
 
   // Add all files listed in any live version to *live.
-  void AddLiveFiles(std::vector<FileDescriptor>* live_list);
+  void AddLiveFiles(std::unordered_map<uint64_t, FileDescriptor>* live_map, InstrumentedMutex& db_mutex);
 
   // Return the approximate size of data to be scanned for range [start, end)
   // in levels [start_level, end_level). If end_level == -1 it will search

--- a/db/version_set.h
+++ b/db/version_set.h
@@ -104,7 +104,10 @@ class VersionStorageInfo {
                      bool _force_consistency_checks);
   ~VersionStorageInfo();
 
-  void Reserve(int level, size_t size) { assert(!finalized_); files_[level].reserve(size); }
+  void Reserve(int level, size_t size) {
+    assert(!finalized_);
+    files_[level].reserve(size);
+  }
 
   void AddFile(int level, FileMetaData* f, Logger* info_log = nullptr);
 
@@ -980,7 +983,8 @@ class VersionSet {
       const EnvOptions& env_options_compactions);
 
   // Add all files listed in any live version to *live.
-  void AddLiveFiles(std::unordered_map<uint64_t, FileDescriptor>* live_map, InstrumentedMutex& db_mutex);
+  void AddLiveFiles(std::unordered_map<uint64_t, FileDescriptor>* live_map,
+                    InstrumentedMutex& db_mutex);
 
   // Return the approximate size of data to be scanned for range [start, end)
   // in levels [start_level, end_level). If end_level == -1 it will search


### PR DESCRIPTION
Signed-off-by: tabokie <xy.tao@outlook.com>

This PR contains two optimizations to reduce DB mutex held time when generating obsolete files purging jobs:
1. Avoid querying live files when there is no obsolete files to purge

This relies on the fact that `PurgeObsoleteFiles()` is only called when `JobContext::HaveSomethingToDelete()` is true, and the job context is unchanged after calling `FindObsoleteFiles()`

2. Query live files outside of DB mutex

This relies on the fact that `Version` will only be public when it's finalized, and finalized version has immutable file list.

We examine the patch in an artificial workload, where iterators are frequently created and released (active iterator count around 250, write OPS around 20K). The logging shows before patching, `AddLiveFiles()` call takes 100+ms and in that process copies 250W file metas with 6W of them being unique.

<p align="center">(left: patched, right: vanilla)</p>
<img width="811" alt="{6CF6D5FB-AF52-4E5D-A8AC-321A8F1D0D18}" src="https://user-images.githubusercontent.com/27005812/123256048-181c1f80-d523-11eb-8a30-3223839d433c.png">
<img width="808" alt="{8D5DEF79-B6F3-4CBC-A1F2-5D4F95C33A1A}" src="https://user-images.githubusercontent.com/27005812/123256066-1d796a00-d523-11eb-9542-b01b5457f84f.png">
<img width="809" alt="{9CA22B47-140B-4971-9C18-FB8F45E4AF79}" src="https://user-images.githubusercontent.com/27005812/123256135-3124d080-d523-11eb-8101-05433001a57e.png">