### PR TITLE
avoid unnecessary live file query and fix double referencing moved file

### DIFF
--- a/db/db_impl/db_impl_files.cc
+++ b/db/db_impl/db_impl_files.cc
@@ -103,7 +103,6 @@ void DBImpl::FindObsoleteFiles(JobContext* job_context, bool force,
   job_context->log_number = MinLogNumberToKeep();
   job_context->prev_log_number = versions_->prev_log_number();
 
-  versions_->AddLiveFiles(&job_context->sst_live);
   if (doing_the_full_scan) {
     InfoLogPrefix info_log_prefix(!immutable_db_options_.db_log_dir.empty(),
                                   dbname_);
@@ -234,6 +233,9 @@ void DBImpl::FindObsoleteFiles(JobContext* job_context, bool force,
   job_context->log_recycle_files.assign(log_recycle_files_.begin(),
                                         log_recycle_files_.end());
   if (job_context->HaveSomethingToDelete()) {
+    if (doing_the_full_scan) {
+      versions_->AddLiveFiles(&job_context->sst_live);
+    }
     ++pending_purge_obsolete_files_;
   }
   logs_to_free_.clear();

--- a/db/job_context.h
+++ b/db/job_context.h
@@ -139,8 +139,8 @@ struct JobContext {
   // (filled only if we're doing full scan)
   std::vector<CandidateFileInfo> full_scan_candidate_files;
 
-  // the list of all live sst files that cannot be deleted
-  std::vector<FileDescriptor> sst_live;
+  // a list of sst files that should not be purged immediately
+  std::vector<FileDescriptor> sst_skip;
 
   // a list of sst files that we need to delete
   std::vector<ObsoleteFileInfo> sst_delete_files;

--- a/db/version_builder.cc
+++ b/db/version_builder.cc
@@ -89,6 +89,7 @@ class VersionBuilder::Rep {
   VersionStorageInfo* base_vstorage_;
   int num_levels_;
   LevelState* levels_;
+  std::unordered_map<uint64_t, FileMetaData*> deleted_base_files_;
   // Store states of levels larger than num_levels_. We do this instead of
   // storing them in levels_ to avoid regression in case there are no files
   // on invalid levels. The version is not consistent if in the end the files
@@ -128,8 +129,7 @@ class VersionBuilder::Rep {
   }
 
   void UnrefFile(FileMetaData* f) {
-    f->refs--;
-    if (f->refs <= 0) {
+    if (f->Unref()) {
       if (f->table_reader_handle) {
         assert(table_cache_ != nullptr);
         table_cache_->ReleaseHandle(f->table_reader_handle);
@@ -406,9 +406,9 @@ class VersionBuilder::Rep {
       while (added_iter != added_end || base_iter != base_end) {
         if (base_iter == base_end ||
                 (added_iter != added_end && cmp(*added_iter, *base_iter))) {
-          MaybeAddFile(vstorage, level, *added_iter++);
+          MaybeAddFile(vstorage, level, *added_iter++, false /*from_base*/);
         } else {
-          MaybeAddFile(vstorage, level, *base_iter++);
+          MaybeAddFile(vstorage, level, *base_iter++, true /*from_base*/);
         }
       }
     }
@@ -514,10 +514,21 @@ class VersionBuilder::Rep {
     return Status::OK();
   }
 
-  void MaybeAddFile(VersionStorageInfo* vstorage, int level, FileMetaData* f) {
+  void MaybeAddFile(VersionStorageInfo* vstorage, int level, FileMetaData* f,
+                    bool from_base) {
+    if (!from_base) {
+      auto it = deleted_base_files_.find(f->fd.GetNumber());
+      if (it != deleted_base_files_.end()) {
+        vstorage->AddFile(level, it->second, info_log_);
+        return;
+      }
+    }
     if (levels_[level].deleted_files.count(f->fd.GetNumber()) > 0) {
       // f is to-be-deleted table file
       vstorage->RemoveCurrentStats(f);
+      if (from_base) {
+        deleted_base_files_[f->fd.GetNumber()] = f;
+      }
     } else {
       vstorage->AddFile(level, f, info_log_);
     }
@@ -557,11 +568,6 @@ Status VersionBuilder::LoadTableHandlers(
   return rep_->LoadTableHandlers(internal_stats, max_threads,
                                  prefetch_index_and_filter_in_cache,
                                  is_initial_load, prefix_extractor);
-}
-
-void VersionBuilder::MaybeAddFile(VersionStorageInfo* vstorage, int level,
-                                  FileMetaData* f) {
-  rep_->MaybeAddFile(vstorage, level, f);
 }
 
 }  // namespace rocksdb

--- a/db/version_builder.h
+++ b/db/version_builder.h
@@ -38,7 +38,6 @@ class VersionBuilder {
                            bool prefetch_index_and_filter_in_cache,
                            bool is_initial_load,
                            const SliceTransform* prefix_extractor);
-  void MaybeAddFile(VersionStorageInfo* vstorage, int level, FileMetaData* f);
 
  private:
   class Rep;

--- a/db/version_builder_test.cc
+++ b/db/version_builder_test.cc
@@ -87,6 +87,24 @@ class VersionBuilderTest : public testing::Test {
   }
 };
 
+struct FileReferenceChecker {
+  std::unordered_map<uint64_t, FileMetaData*> files;
+
+  bool Check(const VersionStorageInfo* vstorage) {
+    for (int i = 0; i < vstorage->num_levels(); i++) {
+      for (auto* f : vstorage->LevelFiles(i)) {
+        auto it = files.find(f->fd.GetNumber());
+        if (it == files.end()) {
+          files[f->fd.GetNumber()] = f;
+        } else if (it->second != f) {
+          return false;
+        }
+      }
+    }
+    return true;
+  }
+};
+
 void UnrefFilesInVersion(VersionStorageInfo* new_vstorage) {
   for (int i = 0; i < new_vstorage->num_levels(); i++) {
     for (auto* f : new_vstorage->LevelFiles(i)) {
@@ -260,19 +278,59 @@ TEST_F(VersionBuilderTest, ApplyDeleteAndSaveTo) {
   version_builder.Apply(&version_edit);
 
   VersionEdit version_edit2;
-  version_edit.AddFile(2, 808, 0, 100U, GetInternalKey("901"),
-                       GetInternalKey("950"), 200, 200, false);
+  version_edit2.AddFile(2, 808, 0, 100U, GetInternalKey("901"),
+                        GetInternalKey("950"), 200, 200, false);
   version_edit2.DeleteFile(2, 616);
   version_edit2.DeleteFile(2, 636);
-  version_edit.AddFile(2, 806, 0, 100U, GetInternalKey("801"),
-                       GetInternalKey("850"), 200, 200, false);
+  version_edit2.AddFile(2, 806, 0, 100U, GetInternalKey("801"),
+                        GetInternalKey("850"), 200, 200, false);
   version_builder.Apply(&version_edit2);
 
   version_builder.SaveTo(&new_vstorage);
 
-  ASSERT_EQ(300U, new_vstorage.NumLevelBytes(2));
+  ASSERT_EQ(500U, new_vstorage.NumLevelBytes(2));
 
   UnrefFilesInVersion(&new_vstorage);
+}
+
+TEST_F(VersionBuilderTest, ApplyMoveAndSaveTo) {
+  UpdateVersionStorageInfo();
+
+  VersionEdit version_edit;
+  version_edit.AddFile(0, 666, 0, 100U, GetInternalKey("301"),
+                       GetInternalKey("350"), 200, 200, false);
+  VersionEdit version_edit2;
+  version_edit2.DeleteFile(0, 666);
+  version_edit2.AddFile(1, 666, 0, 100U, GetInternalKey("301"),
+                        GetInternalKey("350"), 200, 200, false);
+
+  VersionStorageInfo new_vstorage(&icmp_, ucmp_, options_.num_levels,
+                                  kCompactionStyleLevel, nullptr, false);
+  {
+    EnvOptions env_options;
+    VersionBuilder version_builder(env_options, nullptr, &vstorage_);
+    version_builder.Apply(&version_edit);
+    version_builder.SaveTo(&new_vstorage);
+    ASSERT_EQ(100U, new_vstorage.NumLevelBytes(0));
+  }
+
+  VersionStorageInfo new_vstorage2(&icmp_, ucmp_, options_.num_levels,
+                                   kCompactionStyleLevel, nullptr, false);
+  {
+    EnvOptions env_options;
+    VersionBuilder version_builder(env_options, nullptr, &new_vstorage);
+    version_builder.Apply(&version_edit2);
+    version_builder.SaveTo(&new_vstorage2);
+    ASSERT_EQ(0U, new_vstorage2.NumLevelBytes(0));
+    ASSERT_EQ(100U, new_vstorage2.NumLevelBytes(1));
+  }
+
+  FileReferenceChecker checker;
+  ASSERT_TRUE(checker.Check(&new_vstorage));
+  ASSERT_TRUE(checker.Check(&new_vstorage2));
+
+  UnrefFilesInVersion(&new_vstorage);
+  UnrefFilesInVersion(&new_vstorage2);
 }
 
 TEST_F(VersionBuilderTest, EstimatedActiveKeys) {

--- a/db/version_builder_test.cc
+++ b/db/version_builder_test.cc
@@ -40,7 +40,7 @@ class VersionBuilderTest : public testing::Test {
   ~VersionBuilderTest() override {
     for (int i = 0; i < vstorage_.num_levels(); i++) {
       for (auto* f : vstorage_.LevelFiles(i)) {
-        if (--f->refs == 0) {
+        if (f->Unref()) {
           delete f;
         }
       }
@@ -90,7 +90,7 @@ class VersionBuilderTest : public testing::Test {
 void UnrefFilesInVersion(VersionStorageInfo* new_vstorage) {
   for (int i = 0; i < new_vstorage->num_levels(); i++) {
     for (auto* f : new_vstorage->LevelFiles(i)) {
-      if (--f->refs == 0) {
+      if (f->Unref()) {
         delete f;
       }
     }

--- a/db/version_edit.h
+++ b/db/version_edit.h
@@ -129,6 +129,13 @@ struct FileMetaData {
         init_stats_from_file(false),
         marked_for_compaction(false) {}
 
+  void Ref() { ++refs; }
+
+  bool Unref() {
+    --refs;
+    assert(refs >= 0);
+    return refs <= 0;
+  }
   // REQUIRED: Keys must be given to the function in sorted order (it expects
   // the last key to be the largest).
   void UpdateBoundaries(const Slice& key, SequenceNumber seqno) {

--- a/db/version_set.cc
+++ b/db/version_set.cc
@@ -1581,6 +1581,7 @@ VersionStorageInfo::VersionStorageInfo(
       file_indexer_(user_comparator),
       compaction_style_(compaction_style),
       files_(new std::vector<FileMetaData*>[num_levels_]),
+      max_file_number_(0),
       base_level_(num_levels_ == 1 ? -1 : 1),
       level_multiplier_(0.0),
       files_by_compaction_pri_(num_levels_),
@@ -2486,6 +2487,7 @@ bool CompareCompensatedSizeDescending(const Fsize& first, const Fsize& second) {
 } // anonymous namespace
 
 void VersionStorageInfo::AddFile(int level, FileMetaData* f, Logger* info_log) {
+  assert(!finalized_);
   auto* level_files = &files_[level];
   // Must not overlap
 #ifndef NDEBUG
@@ -2510,6 +2512,7 @@ void VersionStorageInfo::AddFile(int level, FileMetaData* f, Logger* info_log) {
 #endif
   f->Ref();
   level_files->push_back(f);
+  max_file_number_ = std::max(max_file_number_, f->fd.GetNumber());
 }
 
 // Version::PrepareApply() need to be called before calling the function, or

--- a/db/version_set.cc
+++ b/db/version_set.cc
@@ -742,9 +742,7 @@ Version::~Version() {
   for (int level = 0; level < storage_info_.num_levels_; level++) {
     for (size_t i = 0; i < storage_info_.files_[level].size(); i++) {
       FileMetaData* f = storage_info_.files_[level][i];
-      assert(f->refs > 0);
-      f->refs--;
-      if (f->refs <= 0) {
+      if (f->Unref()) {
         assert(cfd_ != nullptr);
         uint32_t path_id = f->fd.GetPathId();
         assert(path_id < cfd_->ioptions()->cf_paths.size());
@@ -2510,7 +2508,7 @@ void VersionStorageInfo::AddFile(int level, FileMetaData* f, Logger* info_log) {
 #else
   (void)info_log;
 #endif
-  f->refs++;
+  f->Ref();
   level_files->push_back(f);
 }
 

--- a/db/version_set.h
+++ b/db/version_set.h
@@ -313,6 +313,8 @@ class VersionStorageInfo {
   int base_level() const { return base_level_; }
   double level_multiplier() const { return level_multiplier_; }
 
+  uint64_t max_file_number() const { return max_file_number_; }
+
   // REQUIRES: lock is held
   // Set the index that is used to offset into files_by_compaction_pri_ to find
   // the next compaction candidate file.
@@ -437,6 +439,8 @@ class VersionStorageInfo {
   // List of files per level, files in each level are arranged
   // in increasing order of keys
   std::vector<FileMetaData*>* files_;
+
+  uint64_t max_file_number_;
 
   // Level that L0 data should be compacted to. All levels < base_level_ should
   // be empty. -1 if it is not level-compaction so it's not applicable.

--- a/db/version_set_test.cc
+++ b/db/version_set_test.cc
@@ -118,7 +118,7 @@ class VersionStorageInfoTest : public testing::Test {
   ~VersionStorageInfoTest() override {
     for (int i = 0; i < vstorage_.num_levels(); i++) {
       for (auto* f : vstorage_.LevelFiles(i)) {
-        if (--f->refs == 0) {
+        if (f->Unref()) {
           delete f;
         }
       }


### PR DESCRIPTION
Signed-off-by: tabokie <xy.tao@outlook.com>

Obsolete file candidates consist of `obsolete_files_` that are no longer referenced by any version in `VersionSet`, and all files in DB directory if `doing_full_scan` is true. By design, `obsolete_files_` is guaranteed to be obsolete and thus no need to be checked against live files list. This PR avoids the unnecessary live file query when not doing full scan.

The optimization depends on the assumption that each physical SST file is represented by an unique `FileMetaData` structure, which is actually broken in existing codebase: A trivial file move will create a new file meta for the same file number. This patch also fix this issue.