### PR TITLE
fix version-check  for ingested sst

### DIFF
--- a/db/version_builder.cc
+++ b/db/version_builder.cc
@@ -172,6 +172,9 @@ class VersionBuilder::Rep {
           if (f2->fd.smallest_seqno == f2->fd.largest_seqno) {
             // This is an external file that we ingested
             SequenceNumber external_file_seqno = f2->fd.smallest_seqno;
+            // If f1 and f2 are both ingested files, their seqno may be same.
+            // Because RocksDB will assign only one seqno for all files ingested
+            //  in once call by `IngestExternalFile`.
             if (!((f1->fd.smallest_seqno == f1->fd.largest_seqno &&
                    f1->fd.smallest_seqno == external_file_seqno) ||
                   external_file_seqno < f1->fd.largest_seqno ||

--- a/db/version_builder.cc
+++ b/db/version_builder.cc
@@ -172,7 +172,9 @@ class VersionBuilder::Rep {
           if (f2->fd.smallest_seqno == f2->fd.largest_seqno) {
             // This is an external file that we ingested
             SequenceNumber external_file_seqno = f2->fd.smallest_seqno;
-            if (!(external_file_seqno < f1->fd.largest_seqno ||
+            if (!((f1->fd.smallest_seqno == f1->fd.largest_seqno &&
+                   f1->fd.smallest_seqno == external_file_seqno) ||
+                  external_file_seqno < f1->fd.largest_seqno ||
                   external_file_seqno == 0)) {
               fprintf(stderr,
                       "L0 file with seqno %" PRIu64 " %" PRIu64

--- a/db/version_builder.cc
+++ b/db/version_builder.cc
@@ -174,7 +174,7 @@ class VersionBuilder::Rep {
             SequenceNumber external_file_seqno = f2->fd.smallest_seqno;
             // If f1 and f2 are both ingested files, their seqno may be same.
             // Because RocksDB will assign only one seqno for all files ingested
-            //  in once call by `IngestExternalFile`.
+            // in once call by `IngestExternalFile`.
             if (!((f1->fd.smallest_seqno == f1->fd.largest_seqno &&
                    f1->fd.smallest_seqno == external_file_seqno) ||
                   external_file_seqno < f1->fd.largest_seqno ||


### PR DESCRIPTION
Signed-off-by: Little-Wallace <bupt2013211450@gmail.com>

RocksDB will assign one log sequence number for all sst files which ingested in once call. If all of this files locates in L0, RocksDB will fail to check because the log sequence of them equal.