### PR TITLE
[WIP] Split Write operation for raft-concurrent-apply

### DIFF
--- a/db/db_impl/db_impl.h
+++ b/db/db_impl/db_impl.h
@@ -114,6 +114,8 @@ struct DBWriter {
   DBWriter(const WriteOptions& options, std::vector<WriteBatch*>&& updates)
       : writer(options, std::move(updates), nullptr, 0) {}
   WriteThread::Writer writer;
+
+  bool IsReady() const { return writer.IsReady(); }
 };
 
 // While DB is the public interface of RocksDB, and DBImpl is the actual

--- a/db/db_impl/db_impl.h
+++ b/db/db_impl/db_impl.h
@@ -112,8 +112,8 @@ class Directories {
 
 struct DBWriter {
   DBWriter(const WriteOptions& options, std::vector<WriteBatch*>&& updates)
-      : w(options, std::move(updates), nullptr, 0) {}
-  WriteThread::Writer w;
+      : writer(options, std::move(updates), nullptr, 0) {}
+  WriteThread::Writer writer;
 };
 
 // While DB is the public interface of RocksDB, and DBImpl is the actual

--- a/db/db_impl/db_impl.h
+++ b/db/db_impl/db_impl.h
@@ -160,7 +160,7 @@ class DBImpl : public DB {
   virtual Status Write(const WriteOptions& options,
                        WriteBatch* updates) override;
   using DB::Prepare;
-  virtual void Prepare(const WriteOptions& options, DBWriter* writer) override;
+  virtual void Prepare(DBWriter* writer) override;
   using DB::Submit;
   virtual Status Submit(const WriteOptions& options, DBWriter* writer) override;
 

--- a/db/db_impl/db_impl_write.cc
+++ b/db/db_impl/db_impl_write.cc
@@ -58,7 +58,7 @@ Status DBImpl::Write(const WriteOptions& write_options, WriteBatch* my_batch) {
   return WriteImpl(write_options, my_batch, nullptr, nullptr);
 }
 
-void DBImpl::Prepare(const WriteOptions& write_options, DBWriter* writer) {
+void DBImpl::Prepare(DBWriter* writer) {
   write_thread_.JoinBatchGroupNoBlocking(&writer->writer);
 }
 

--- a/db/db_test.cc
+++ b/db/db_test.cc
@@ -2584,7 +2584,7 @@ class ModelDB : public DB {
     return batch->Iterate(&handler);
   }
   using DB::Prepare;
-  void Prepare(const WriteOptions& options, DBWriter* writer) override {}
+  void Prepare(DBWriter* writer) override {}
   using DB::Submit;
   Status Submit(const WriteOptions& options, DBWriter* writer) override {
     return Status::NotSupported("Not implemented");

--- a/db/db_test.cc
+++ b/db/db_test.cc
@@ -2422,6 +2422,8 @@ namespace {
 typedef std::map<std::string, std::string> KVMap;
 }
 
+struct DBWriter;
+
 class ModelDB : public DB {
  public:
   class ModelSnapshot : public Snapshot {
@@ -2580,6 +2582,12 @@ class ModelDB : public DB {
     Handler handler;
     handler.map_ = &map_;
     return batch->Iterate(&handler);
+  }
+  using DB::Prepare;
+  void Prepare(const WriteOptions& options, DBWriter* writer) override {}
+  using DB::Submit;
+  Status Submit(const WriteOptions& options, DBWriter* writer) override {
+    return Status::NotSupported("Not implemented");
   }
 
   using DB::GetProperty;

--- a/db/write_thread.h
+++ b/db/write_thread.h
@@ -302,6 +302,8 @@ class WriteThread {
   //
   // Writer* w:        Writer to be executed as part of a batch group
   void JoinBatchGroup(Writer* w);
+  void JoinBatchGroupNoBlocking(Writer* w);
+  void AwaitStateForGroupLeader(Writer* w);
 
   // Constructs a write batch group led by leader, which should be a
   // Writer passed to JoinBatchGroup on the current thread.

--- a/db/write_thread.h
+++ b/db/write_thread.h
@@ -258,6 +258,12 @@ class WriteThread {
       return status.ok() && !CallbackFailed() && !disable_wal;
     }
 
+    bool IsReady() const {
+      static uint8_t goal = STATE_GROUP_LEADER | STATE_MEMTABLE_WRITER_LEADER |
+                            STATE_PARALLEL_MEMTABLE_WRITER | STATE_COMPLETED;
+      return (state.load(std::memory_order_acquire) | goal) != 0;
+    }
+
     // No other mutexes may be acquired while holding StateMutex(), it is
     // always last in the order
     std::mutex& StateMutex() {

--- a/db/write_thread.h
+++ b/db/write_thread.h
@@ -301,7 +301,6 @@ class WriteThread {
   // it will block.
   //
   // Writer* w:        Writer to be executed as part of a batch group
-  void JoinBatchGroup(Writer* w);
   void JoinBatchGroupNoBlocking(Writer* w);
   void AwaitStateForGroupLeader(Writer* w);
 

--- a/include/rocksdb/db.h
+++ b/include/rocksdb/db.h
@@ -379,7 +379,7 @@ class DB {
   // Returns OK on success, non-OK on failure.
   // Note: consider setting options.sync = true.
   virtual Status Write(const WriteOptions& options, WriteBatch* updates) = 0;
-  virtual void Prepare(const WriteOptions& options, DBWriter* writer) = 0;
+  virtual void Prepare(DBWriter* writer) = 0;
   virtual Status Submit(const WriteOptions& options, DBWriter* writer) = 0;
 
   virtual Status MultiBatchWrite(const WriteOptions& /*options*/,

--- a/include/rocksdb/db.h
+++ b/include/rocksdb/db.h
@@ -54,6 +54,7 @@ class Env;
 class EventListener;
 class StatsHistoryIterator;
 class TraceWriter;
+struct DBWriter;
 #ifdef ROCKSDB_LITE
 class CompactionJobInfo;
 #endif
@@ -378,6 +379,8 @@ class DB {
   // Returns OK on success, non-OK on failure.
   // Note: consider setting options.sync = true.
   virtual Status Write(const WriteOptions& options, WriteBatch* updates) = 0;
+  virtual void Prepare(const WriteOptions& options, DBWriter* writer) = 0;
+  virtual Status Submit(const WriteOptions& options, DBWriter* writer) = 0;
 
   virtual Status MultiBatchWrite(const WriteOptions& /*options*/,
                                  std::vector<WriteBatch*>&& /*updates*/) {

--- a/include/rocksdb/utilities/stackable_db.h
+++ b/include/rocksdb/utilities/stackable_db.h
@@ -165,8 +165,7 @@ class StackableDB : public DB {
   virtual Status Write(const WriteOptions& opts, WriteBatch* updates) override {
     return db_->Write(opts, updates);
   }
-  virtual void Prepare(const WriteOptions& options, DBWriter* writer) override {
-  }
+  virtual void Prepare(DBWriter* writer) override {}
   virtual Status Submit(const WriteOptions& options,
                         DBWriter* writer) override {
     return Status::NotSupported("Not implemented");

--- a/include/rocksdb/utilities/stackable_db.h
+++ b/include/rocksdb/utilities/stackable_db.h
@@ -15,6 +15,7 @@
 #endif
 
 namespace rocksdb {
+struct DBWriter;
 
 // This class contains APIs to stack rocksdb wrappers.Eg. Stack TTL over base d
 class StackableDB : public DB {
@@ -163,6 +164,12 @@ class StackableDB : public DB {
 
   virtual Status Write(const WriteOptions& opts, WriteBatch* updates) override {
     return db_->Write(opts, updates);
+  }
+  virtual void Prepare(const WriteOptions& options, DBWriter* writer) override {
+  }
+  virtual Status Submit(const WriteOptions& options,
+                        DBWriter* writer) override {
+    return Status::NotSupported("Not implemented");
   }
 
   using DB::NewIterator;

--- a/utilities/blob_db/blob_db_impl.h
+++ b/utilities/blob_db/blob_db_impl.h
@@ -37,6 +37,7 @@
 namespace rocksdb {
 
 class DBImpl;
+struct DBWriter;
 class ColumnFamilyHandle;
 class ColumnFamilyData;
 struct FlushJobInfo;
@@ -137,6 +138,12 @@ class BlobDBImpl : public BlobDB {
       std::vector<std::string>* values) override;
 
   virtual Status Write(const WriteOptions& opts, WriteBatch* updates) override;
+  virtual void Prepare(const WriteOptions& options, DBWriter* writer) override {
+  }
+  virtual Status Submit(const WriteOptions& options,
+                        DBWriter* writer) override {
+    return Status::NotSupported("Not implemented");
+  }
 
   virtual Status Close() override;
 

--- a/utilities/blob_db/blob_db_impl.h
+++ b/utilities/blob_db/blob_db_impl.h
@@ -138,8 +138,7 @@ class BlobDBImpl : public BlobDB {
       std::vector<std::string>* values) override;
 
   virtual Status Write(const WriteOptions& opts, WriteBatch* updates) override;
-  virtual void Prepare(const WriteOptions& options, DBWriter* writer) override {
-  }
+  virtual void Prepare(DBWriter* writer) override {}
   virtual Status Submit(const WriteOptions& options,
                         DBWriter* writer) override {
     return Status::NotSupported("Not implemented");


### PR DESCRIPTION
### Problem
If we build a raft group based on RocksDB, we hope the data of raft can be applied in order of  raft-log-index. But it will be slowly if there are a lot of entries waiting to be applied, one thread can not consume them as soon as possible. 

And for TiKV batch-system, we hope to process data from different regions in a first-come, first-served manner. This also need to guarantee the order of entries consumed in different thread.

### Solution

We hope we can write these keys in parallel by multiple thread. We only need to guarantee that one entry must start writing operation after theses entries whose log-index are less than it. We will use a atomic applied index to decide whether one entry is writing to db.

```rust
let mut wb = db.new_write_batch();
let mut starting = vec![];
while let Some(m) = receiver.try_recv() {
      let region = globalRegionMap.get(m.get_region_id());
      if region.last_applying_index.load(Odering::Acquire) + 1 == m.get_first_log_index() {
           starting.push((region.last_applying_index.clone(), m.get_last_log_index()));
           for (k,v) in m.kvs() {
                wb.put(m);
           }
      } else {
           region.restore_entries(m);
      }
}
db.prepare(&wb);
for (k,v) in starting {
     k.store(v, Ordering::release);
}
db.submit(&wb);
```

