### PR TITLE
optimize `GetTotalSstFilesSize`

### DIFF
--- a/db/compaction/compaction_picker_test.cc
+++ b/db/compaction/compaction_picker_test.cc
@@ -96,7 +96,7 @@ class CompactionPickerTest : public testing::Test {
     f->fd.largest_seqno = largest_seq;
     f->compensated_file_size =
         (compensated_file_size != 0) ? compensated_file_size : file_size;
-    vstorage_->AddFile(level, f);
+    vstorage_->AddFile(level, f, true /*new_file*/);
     files_.emplace_back(f);
     file_map_.insert({file_number, {f, level}});
   }

--- a/db/version_builder.cc
+++ b/db/version_builder.cc
@@ -424,6 +424,8 @@ class VersionBuilder::Rep {
       return s;
     }
 
+    uint64_t total_file_size = 0;
+    int64_t delta_file_size = 0;
     for (int level = 0; level < num_levels_; level++) {
       const auto& cmp = (level == 0) ? level_zero_cmp_ : level_nonzero_cmp_;
       // Merge the set of added files with the set of pre-existing files.
@@ -483,7 +485,7 @@ class VersionBuilder::Rep {
             assert(unordered_added_files.find(file_number) ==
                    unordered_added_files.end());
 #endif
-            vstorage->AddFile(level, f, info_log_);
+            vstorage->AddFile(level, f, false /*new_file*/, info_log_);
           }
         } else {
           FileMetaData* f = *delta_iter++;
@@ -492,7 +494,7 @@ class VersionBuilder::Rep {
             // deleted from it.
             vstorage->UpdateAccumulatedStats(f);
           }
-          vstorage->AddFile(level, f, info_log_);
+          vstorage->AddFile(level, f, f->being_moved_to != level /*new_file*/, info_log_);
         }
       }
     }

--- a/db/version_builder.cc
+++ b/db/version_builder.cc
@@ -492,7 +492,8 @@ class VersionBuilder::Rep {
             // deleted from it.
             vstorage->UpdateAccumulatedStats(f);
           }
-          vstorage->AddFile(level, f, f->being_moved_to != level /*new_file*/, info_log_);
+          vstorage->AddFile(level, f, f->being_moved_to != level /*new_file*/,
+                            info_log_);
         }
       }
     }

--- a/db/version_builder.cc
+++ b/db/version_builder.cc
@@ -424,8 +424,6 @@ class VersionBuilder::Rep {
       return s;
     }
 
-    uint64_t total_file_size = 0;
-    int64_t delta_file_size = 0;
     for (int level = 0; level < num_levels_; level++) {
       const auto& cmp = (level == 0) ? level_zero_cmp_ : level_nonzero_cmp_;
       // Merge the set of added files with the set of pre-existing files.

--- a/db/version_builder_test.cc
+++ b/db/version_builder_test.cc
@@ -69,7 +69,7 @@ class VersionBuilderTest : public testing::Test {
     f->compensated_file_size = file_size;
     f->num_entries = num_entries;
     f->num_deletions = num_deletions;
-    vstorage_.AddFile(level, f);
+    vstorage_.AddFile(level, f, true /*new_file*/);
     if (sampled) {
       f->init_stats_from_file = true;
       vstorage_.UpdateAccumulatedStats(f);

--- a/db/version_set.cc
+++ b/db/version_set.cc
@@ -2550,7 +2550,8 @@ bool CompareCompensatedSizeDescending(const Fsize& first, const Fsize& second) {
 }
 } // anonymous namespace
 
-void VersionStorageInfo::AddFile(int level, FileMetaData* f, bool new_file, Logger* info_log) {
+void VersionStorageInfo::AddFile(int level, FileMetaData* f, bool new_file,
+                                 Logger* info_log) {
   auto& level_files = files_[level];
   // Must not overlap
 #ifndef NDEBUG
@@ -2582,7 +2583,7 @@ void VersionStorageInfo::AddFile(int level, FileMetaData* f, bool new_file, Logg
   assert(file_locations_.find(file_number) == file_locations_.end());
   file_locations_.emplace(file_number,
                           FileLocation(level, level_files.size() - 1));
-  
+
   auto file_size = f->fd.GetFileSize();
   total_file_size_ += file_size;
   if (new_file) {
@@ -5395,9 +5396,9 @@ uint64_t VersionSet::GetTotalSstFilesSize(Version* dummy_versions) {
   for (Version* v = dummy_versions->next_; v != dummy_versions; v = v->next_) {
     VersionStorageInfo* storage_info = v->storage_info();
     if (total_size == 0) {
-      total_size = storage_info.total_file_size_;
+      total_size = storage_info->total_file_size_;
     } else {
-      total_size += storage_info.new_file_size_;
+      total_size += storage_info->new_file_size_;
     }
   }
 #ifndef NDEBUG
@@ -5415,7 +5416,7 @@ uint64_t VersionSet::GetTotalSstFilesSize(Version* dummy_versions) {
       }
     }
   }
-  assert!(total_size == total_size2);
+  assert(total_size == total_size2);
 #endif
   return total_size;
 }

--- a/db/version_set.h
+++ b/db/version_set.h
@@ -106,7 +106,8 @@ class VersionStorageInfo {
 
   void Reserve(int level, size_t size) { files_[level].reserve(size); }
 
-  void AddFile(int level, FileMetaData* f, bool new_file, Logger* info_log = nullptr);
+  void AddFile(int level, FileMetaData* f, bool new_file,
+               Logger* info_log = nullptr);
 
   void SetFinalized();
 

--- a/db/version_set.h
+++ b/db/version_set.h
@@ -106,7 +106,7 @@ class VersionStorageInfo {
 
   void Reserve(int level, size_t size) { files_[level].reserve(size); }
 
-  void AddFile(int level, FileMetaData* f, Logger* info_log = nullptr);
+  void AddFile(int level, FileMetaData* f, bool new_file, Logger* info_log = nullptr);
 
   void SetFinalized();
 
@@ -583,6 +583,11 @@ class VersionStorageInfo {
   // Estimated bytes needed to be compacted until all levels' size is down to
   // target sizes.
   uint64_t estimated_compaction_needed_bytes_;
+
+  // total size of all files
+  uint64_t total_file_size_;
+  // total size of newly created files
+  uint64_t new_file_size_;
 
   bool finalized_;
 

--- a/db/version_set_test.cc
+++ b/db/version_set_test.cc
@@ -148,7 +148,7 @@ class VersionStorageInfoTest : public testing::Test {
     f->compensated_file_size = file_size;
     f->num_entries = 0;
     f->num_deletions = 0;
-    vstorage_.AddFile(level, f, trie /*new_file*/);
+    vstorage_.AddFile(level, f, true /*new_file*/);
   }
 
   std::string GetOverlappingFiles(int level, const InternalKey& begin,

--- a/db/version_set_test.cc
+++ b/db/version_set_test.cc
@@ -135,7 +135,7 @@ class VersionStorageInfoTest : public testing::Test {
     f->compensated_file_size = file_size;
     f->num_entries = 0;
     f->num_deletions = 0;
-    vstorage_.AddFile(level, f);
+    vstorage_.AddFile(level, f, true /*new_file*/);
   }
 
   void Add(int level, uint32_t file_number, const InternalKey& smallest,
@@ -148,7 +148,7 @@ class VersionStorageInfoTest : public testing::Test {
     f->compensated_file_size = file_size;
     f->num_entries = 0;
     f->num_deletions = 0;
-    vstorage_.AddFile(level, f);
+    vstorage_.AddFile(level, f, trie /*new_file*/);
   }
 
   std::string GetOverlappingFiles(int level, const InternalKey& begin,

--- a/include/rocksdb/write_batch.h
+++ b/include/rocksdb/write_batch.h
@@ -309,10 +309,10 @@ class WriteBatch : public WriteBatchBase {
   // Returns true if MarkEndPrepare will be called during Iterate
   bool HasEndPrepare() const;
 
-  // Returns trie if MarkCommit will be called during Iterate
+  // Returns true if MarkCommit will be called during Iterate
   bool HasCommit() const;
 
-  // Returns trie if MarkRollback will be called during Iterate
+  // Returns true if MarkRollback will be called during Iterate
   bool HasRollback() const;
 
   // Assign timestamp to write batch


### PR DESCRIPTION
Signed-off-by: tabokie <xy.tao@outlook.com>

Cache total file size and newly created file size in version storage. Engine used size = total_file_size[v=oldest] + sum(new_file_size[oldest+1..=newest])

Fix https://github.com/tikv/tikv/issues/11060