### PR TITLE
Add set_severity for Status class

### DIFF
--- a/include/rocksdb/status.h
+++ b/include/rocksdb/status.h
@@ -93,6 +93,10 @@ class Status {
   Status(const Status& s, Severity sev);
   Severity severity() const { return sev_; }
 
+  void set_severity(Severity sev) {
+    sev_ = sev;
+  }
+
   // Returns a C style string indicating the message of the Status
   const char* getState() const { return state_; }
 


### PR DESCRIPTION
here `status` passes a pointer not a pointer to another pointer so we maybe need a `set_severity` to change severity. This api allows users to customize status returned from rocksdb internal error.
```
virtual void OnBackgroundError(BackgroundErrorReason reason, Status* status)
```

Signed-off-by: Xintao <hunterlxt@live.com>