### PR TITLE
reduce scanning of filemeta during purge and sizing

### DIFF
--- a/db/compaction/compaction_picker_test.cc
+++ b/db/compaction/compaction_picker_test.cc
@@ -119,7 +119,7 @@ class CompactionPickerTest : public testing::Test {
     f->compensated_file_size =
         (compensated_file_size != 0) ? compensated_file_size : file_size;
     f->oldest_ancester_time = oldest_ancestor_time;
-    vstorage->AddFile(level, f);
+    vstorage->AddFile(level, f, true /*newly_added*/);
     files_.emplace_back(f);
     file_map_.insert({file_number, {f, level}});
   }

--- a/db/deletefile_test.cc
+++ b/db/deletefile_test.cc
@@ -417,6 +417,7 @@ TEST_F(DeleteFileTest, BackgroundPurgeTestMultipleJobs) {
   SetOptions(&options);
   Destroy(options);
   options.create_if_missing = true;
+  options.disable_auto_compactions = true;
   Reopen(options);
 
   std::string first("0"), last("999999");
@@ -427,14 +428,21 @@ TEST_F(DeleteFileTest, BackgroundPurgeTestMultipleJobs) {
 
   // We keep an iterator alive
   CreateTwoLevels();
+  std::cout << "----" << std::endl;
   ReadOptions read_options;
   read_options.background_purge_on_iterator_cleanup = true;
   Iterator* itr1 = db_->NewIterator(read_options);
+  std::cout << "----" << std::endl;
   ASSERT_OK(itr1->status());
+  CheckFileTypeCounts(dbname_, 0, 2, 1);
   CreateTwoLevels();
+  std::cout << "----" << std::endl;
   Iterator* itr2 = db_->NewIterator(read_options);
+  std::cout << "----" << std::endl;
   ASSERT_OK(itr2->status());
+  CheckFileTypeCounts(dbname_, 0, 4, 1);
   ASSERT_OK(db_->CompactRange(compact_options, &first_slice, &last_slice));
+  std::cout << "----" << std::endl;
   // 5 sst files after 2 compactions with 2 live iterators
   CheckFileTypeCounts(dbname_, 0, 5, 1);
 

--- a/db/version_builder.cc
+++ b/db/version_builder.cc
@@ -1074,12 +1074,16 @@ class VersionBuilder::Rep {
       const auto& add_files = level_state.added_files;
       const auto add_it = add_files.find(file_number);
 
-      // Note: if the file appears both in the base version and in the added
-      // list, the added FileMetaData supersedes the one in the base version.
-      if (add_it != add_files.end() && add_it->second != f) {
-        vstorage->RemoveCurrentStats(f);
+      if (add_it != add_files.end()) {
+        // Note: if the file appears both in the base version and in the added
+        // list, the added FileMetaData supersedes the one in the base version.
+        if (add_it->second != f) {
+          vstorage->RemoveCurrentStats(f);
+        } else {
+          vstorage->AddFile(level, f, true /*newly_added*/);
+        }
       } else {
-        vstorage->AddFile(level, f);
+        vstorage->AddFile(level, f, false /*newly_added*/);
       }
     }
   }

--- a/db/version_builder.cc
+++ b/db/version_builder.cc
@@ -1074,16 +1074,12 @@ class VersionBuilder::Rep {
       const auto& add_files = level_state.added_files;
       const auto add_it = add_files.find(file_number);
 
-      if (add_it != add_files.end()) {
-        // Note: if the file appears both in the base version and in the added
-        // list, the added FileMetaData supersedes the one in the base version.
-        if (add_it->second != f) {
-          vstorage->RemoveCurrentStats(f);
-        } else {
-          vstorage->AddFile(level, f, true /*newly_added*/);
-        }
+      // Note: if the file appears both in the base version and in the added
+      // list, the added FileMetaData supersedes the one in the base version.
+      if (add_it != add_files.end() && add_it->second != f) {
+        vstorage->RemoveCurrentStats(f);
       } else {
-        vstorage->AddFile(level, f, false /*newly_added*/);
+        vstorage->AddFile(level, f, add_it != add_files.end() /*newly_added*/);
       }
     }
   }

--- a/db/version_builder_test.cc
+++ b/db/version_builder_test.cc
@@ -76,7 +76,7 @@ class VersionBuilderTest : public testing::Test {
     f->compensated_file_size = file_size;
     f->num_entries = num_entries;
     f->num_deletions = num_deletions;
-    vstorage_.AddFile(level, f);
+    vstorage_.AddFile(level, f, true /*newly_added*/);
     if (sampled) {
       f->init_stats_from_file = true;
       vstorage_.UpdateAccumulatedStats(f);

--- a/db/version_set.cc
+++ b/db/version_set.cc
@@ -20,6 +20,8 @@
 #include <unordered_map>
 #include <vector>
 
+#include <iostream>
+
 #include "db/blob/blob_fetcher.h"
 #include "db/blob/blob_file_cache.h"
 #include "db/blob/blob_file_reader.h"
@@ -755,6 +757,12 @@ Version::~Version() {
             ObsoleteFileInfo(f, cfd_->ioptions()->cf_paths[path_id].path));
       }
     }
+  }
+
+  // Copy new files to next version.
+  if (cfd_ && cfd_->dummy_versions() != next_) {
+    auto& next_vstorage = next_->storage_info_.new_files_;
+    next_vstorage.insert(next_vstorage.end(), storage_info_.new_files_.begin(), storage_info_.new_files_.end());
   }
 }
 
@@ -3055,6 +3063,7 @@ bool CompareCompensatedSizeDescending(const Fsize& first, const Fsize& second) {
 } // anonymous namespace
 
 void VersionStorageInfo::AddFile(int level, FileMetaData* f, bool newly_added) {
+  std::cout << "AddFile level=" << level << " number=" << f->fd.GetNumber() << " new=" << newly_added << std::endl;
   auto& level_files = files_[level];
   level_files.push_back(f);
 

--- a/db/version_set.cc
+++ b/db/version_set.cc
@@ -1722,6 +1722,7 @@ VersionStorageInfo::VersionStorageInfo(
       file_indexer_(user_comparator),
       compaction_style_(compaction_style),
       files_(new std::vector<FileMetaData*>[num_levels_]),
+      new_files_(1),
       base_level_(num_levels_ == 1 ? -1 : 1),
       level_multiplier_(0.0),
       files_by_compaction_pri_(num_levels_),
@@ -1739,6 +1740,8 @@ VersionStorageInfo::VersionStorageInfo(
       current_num_deletions_(0),
       current_num_samples_(0),
       estimated_compaction_needed_bytes_(0),
+      total_file_size_(0),
+      new_file_size_(0),
       finalized_(false),
       force_consistency_checks_(_force_consistency_checks) {
   if (ref_vstorage != nullptr) {
@@ -3053,7 +3056,7 @@ bool CompareCompensatedSizeDescending(const Fsize& first, const Fsize& second) {
 }
 } // anonymous namespace
 
-void VersionStorageInfo::AddFile(int level, FileMetaData* f) {
+void VersionStorageInfo::AddFile(int level, FileMetaData* f, bool newly_added) {
   auto& level_files = files_[level];
   level_files.push_back(f);
 
@@ -3064,6 +3067,13 @@ void VersionStorageInfo::AddFile(int level, FileMetaData* f) {
   assert(file_locations_.find(file_number) == file_locations_.end());
   file_locations_.emplace(file_number,
                           FileLocation(level, level_files.size() - 1));
+
+  auto file_size = f->fd.GetFileSize();
+  total_file_size_ += file_size;
+  if (newly_added) {
+    new_files_.push_back(f);
+    new_file_size_ += file_size;
+  }
 }
 
 void VersionStorageInfo::AddBlobFile(
@@ -3891,16 +3901,24 @@ bool VersionStorageInfo::RangeMightExistAfterSortedRun(
 }
 
 void Version::AddLiveFiles(std::vector<uint64_t>* live_table_files,
-                           std::vector<uint64_t>* live_blob_files) const {
+                           std::vector<uint64_t>* live_blob_files,
+                           bool only_new_table_files) const {
   assert(live_table_files);
   assert(live_blob_files);
 
-  for (int level = 0; level < storage_info_.num_levels(); ++level) {
-    const auto& level_files = storage_info_.LevelFiles(level);
-    for (const auto& meta : level_files) {
+  if (only_new_table_files) {
+    const auto& files = storage_info_.NewlyAddedFiles();
+    for (const auto& meta : files) {
       assert(meta);
-
       live_table_files->emplace_back(meta->fd.GetNumber());
+    }
+  } else {
+    for (int level = 0; level < storage_info_.num_levels(); ++level) {
+      const auto& level_files = storage_info_.LevelFiles(level);
+      for (const auto& meta : level_files) {
+        assert(meta);
+        live_table_files->emplace_back(meta->fd.GetNumber());
+      }
     }
   }
 
@@ -5675,7 +5693,8 @@ uint64_t VersionSet::ApproximateSize(Version* v, const FdWithKeyRange& f,
 }
 
 void VersionSet::AddLiveFiles(std::vector<uint64_t>* live_table_files,
-                              std::vector<uint64_t>* live_blob_files) const {
+                              std::vector<uint64_t>* live_blob_files,
+                              bool only_new_table_files) const {
   assert(live_table_files);
   assert(live_blob_files);
 
@@ -5693,18 +5712,24 @@ void VersionSet::AddLiveFiles(std::vector<uint64_t>* live_table_files,
 
     Version* const dummy_versions = cfd->dummy_versions();
     assert(dummy_versions);
+    Version* v = dummy_versions->next_;
+    // Scan the full list of files from the first version.
+    const auto* vstorage0 = v->storage_info();
+    assert(vstorage0);
+    for (int level = 0; level < vstorage0->num_levels(); ++level) {
+      total_table_files += vstorage0->LevelFiles(level).size();
+    }
+    total_blob_files += vstorage0->GetBlobFiles().size();
+    v = v->next_;
 
-    for (Version* v = dummy_versions->next_; v != dummy_versions;
-         v = v->next_) {
+    // Scan the delta list of files from other versions.
+    for (; v != dummy_versions; v = v->next_) {
       assert(v);
 
       const auto* vstorage = v->storage_info();
       assert(vstorage);
 
-      for (int level = 0; level < vstorage->num_levels(); ++level) {
-        total_table_files += vstorage->LevelFiles(level).size();
-      }
-
+      total_table_files += vstorage->NewlyAddedFiles().size();
       total_blob_files += vstorage->GetBlobFiles().size();
     }
   }
@@ -5725,10 +5750,15 @@ void VersionSet::AddLiveFiles(std::vector<uint64_t>* live_table_files,
 
     Version* const dummy_versions = cfd->dummy_versions();
     assert(dummy_versions);
+    Version* v = dummy_versions->next_;
+    // Get the full list of files from the first version.
+    v->AddLiveFiles(live_table_files, live_blob_files,
+                    false /*only_new_table_files*/);
+    v = v->next_;
 
-    for (Version* v = dummy_versions->next_; v != dummy_versions;
-         v = v->next_) {
-      v->AddLiveFiles(live_table_files, live_blob_files);
+    for (; v != dummy_versions; v = v->next_) {
+      v->AddLiveFiles(live_table_files, live_blob_files,
+                      true /*only_new_table_files*/);
       if (v == current) {
         found_current = true;
       }
@@ -5737,7 +5767,8 @@ void VersionSet::AddLiveFiles(std::vector<uint64_t>* live_table_files,
     if (!found_current && current != nullptr) {
       // Should never happen unless it is a bug.
       assert(false);
-      current->AddLiveFiles(live_table_files, live_blob_files);
+      current->AddLiveFiles(live_table_files, live_blob_files,
+                            false /*only_new_table_files*/);
     }
   }
 }
@@ -5935,8 +5966,18 @@ uint64_t VersionSet::GetNumLiveVersions(Version* dummy_versions) {
 }
 
 uint64_t VersionSet::GetTotalSstFilesSize(Version* dummy_versions) {
+  uint64_t total_size = 0;
+  for (Version* v = dummy_versions->next_; v != dummy_versions; v = v->next_) {
+    VersionStorageInfo* storage_info = v->storage_info();
+    if (total_size == 0) {
+      total_size = storage_info->total_file_size_;
+    } else {
+      total_size += storage_info->new_file_size_;
+    }
+  }
+#ifndef NDEBUG
   std::unordered_set<uint64_t> unique_files;
-  uint64_t total_files_size = 0;
+  uint64_t total_size2 = 0;
   for (Version* v = dummy_versions->next_; v != dummy_versions; v = v->next_) {
     VersionStorageInfo* storage_info = v->storage_info();
     for (int level = 0; level < storage_info->num_levels_; level++) {
@@ -5944,12 +5985,14 @@ uint64_t VersionSet::GetTotalSstFilesSize(Version* dummy_versions) {
         if (unique_files.find(file_meta->fd.packed_number_and_path_id) ==
             unique_files.end()) {
           unique_files.insert(file_meta->fd.packed_number_and_path_id);
-          total_files_size += file_meta->fd.GetFileSize();
+          total_size2 += file_meta->fd.GetFileSize();
         }
       }
     }
   }
-  return total_files_size;
+  assert(total_size == total_size2);
+#endif  // !NDEBUG
+  return total_size;
 }
 
 uint64_t VersionSet::GetTotalBlobFileSize(Version* dummy_versions) {

--- a/db/version_set.h
+++ b/db/version_set.h
@@ -656,11 +656,6 @@ class VersionStorageInfo {
   // target sizes.
   uint64_t estimated_compaction_needed_bytes_;
 
-  // total size of all table files
-  uint64_t total_file_size_;
-  // total size of newly added table files
-  uint64_t new_file_size_;
-
   bool finalized_;
 
   // If set to true, we will run consistency checks even if RocksDB
@@ -1257,8 +1252,7 @@ class VersionSet {
   // Add all files listed in any live version to *live_table_files and
   // *live_blob_files. Note that these lists may contain duplicates.
   void AddLiveFiles(std::vector<uint64_t>* live_table_files,
-                    std::vector<uint64_t>* live_blob_files,
-                    bool only_new_table_files = false) const;
+                    std::vector<uint64_t>* live_blob_files) const;
 
   // Return the approximate size of data to be scanned for range [start, end)
   // in levels [start_level, end_level). If end_level == -1 it will search

--- a/db/version_set_test.cc
+++ b/db/version_set_test.cc
@@ -160,7 +160,7 @@ class VersionStorageInfoTestBase : public testing::Test {
         kUnknownFileChecksum, kUnknownFileChecksumFuncName,
         kDisableUserTimestamp, kDisableUserTimestamp);
     f->compensated_file_size = file_size;
-    vstorage_.AddFile(level, f);
+    vstorage_.AddFile(level, f, true /*newly_added*/);
   }
 
   void AddBlob(uint64_t blob_file_number, uint64_t total_blob_count,


### PR DESCRIPTION
Upstream PR: https://github.com/facebook/rocksdb/pull/10022

For read-heavy workload over large dataset, excessive filemeta scanning has been causing foreground performance jitters for us. See https://github.com/facebook/rocksdb/pull/8494 for more details.

This patch reduces scanning filemeta by identifying and storing newly added files into a separate field of `VersionStorageInfo`. This implementation is much simpler than previous attempt.

Signed-off-by: tabokie <xy.tao@outlook.com>