### PR TITLE
Fix SIGABRT caused by uninitialized mutex

### DIFF
--- a/db/write_thread.cc
+++ b/db/write_thread.cc
@@ -825,7 +825,7 @@ void WriteThread::Writer::ConsumeOne(size_t claimed) {
       multi_batch.ignore_missing_column_families, 0, this->log_ref,
       multi_batch.db, true);
   if (!s.ok()) {
-    std::lock_guard<std::mutex> guard(this->status_mu);
+    std::lock_guard<SpinMutex> guard(this->status_lock);
     this->status = s;
   }
   multi_batch.pending_wb_cnt.fetch_sub(1, std::memory_order_acq_rel);

--- a/db/write_thread.cc
+++ b/db/write_thread.cc
@@ -825,7 +825,7 @@ void WriteThread::Writer::ConsumeOne(size_t claimed) {
       multi_batch.ignore_missing_column_families, 0, this->log_ref,
       multi_batch.db, true);
   if (!s.ok()) {
-    std::lock_guard<std::mutex> guard(this->StateMutex());
+    std::lock_guard<std::mutex> guard(this->status_mu);
     this->status = s;
   }
   multi_batch.pending_wb_cnt.fetch_sub(1, std::memory_order_acq_rel);

--- a/db/write_thread.h
+++ b/db/write_thread.h
@@ -26,6 +26,7 @@
 #include "rocksdb/types.h"
 #include "rocksdb/write_batch.h"
 #include "util/autovector.h"
+#include "util/mutexlock.h"
 
 namespace rocksdb {
 
@@ -184,8 +185,8 @@ class WriteThread {
     WriteGroup* write_group;
     CommitRequest* request;
     SequenceNumber sequence;  // the sequence number to use for the first key
-    Status status;
-    std::mutex status_mu;
+    Status status; // this field is protected by status_lock instead of db_mutex
+    SpinMutex status_lock;
     Status callback_status;   // status returned by callback->Callback()
 
     std::aligned_storage<sizeof(std::mutex)>::type state_mutex_bytes;

--- a/db/write_thread.h
+++ b/db/write_thread.h
@@ -185,6 +185,7 @@ class WriteThread {
     CommitRequest* request;
     SequenceNumber sequence;  // the sequence number to use for the first key
     Status status;
+    std::mutex status_mu;
     Status callback_status;   // status returned by callback->Callback()
 
     std::aligned_storage<sizeof(std::mutex)>::type state_mutex_bytes;

--- a/db/write_thread.h
+++ b/db/write_thread.h
@@ -185,7 +185,7 @@ class WriteThread {
     WriteGroup* write_group;
     CommitRequest* request;
     SequenceNumber sequence;  // the sequence number to use for the first key
-    Status status; // this field is protected by status_lock instead of db_mutex
+    Status status;  // write protected by status_lock in multi batch write.
     SpinMutex status_lock;
     Status callback_status;   // status returned by callback->Callback()
 


### PR DESCRIPTION
Fixed bug where wrong use of uninitialized Mutex caused SIGABRT.


Signed-off-by: Wenbo Zhang <ethercflow@gmail.com>