### PR TITLE
Fix SIGABRT caused by uninitialized mutex (#296)

### DIFF
--- a/db/write_thread.cc
+++ b/db/write_thread.cc
@@ -861,7 +861,7 @@ void WriteThread::Writer::ConsumeOne(size_t claimed) {
       multi_batch.ignore_missing_column_families, 0, this->log_ref,
       multi_batch.db, true);
   if (!s.ok()) {
-    std::lock_guard<std::mutex> guard(this->StateMutex());
+    std::lock_guard<SpinMutex> guard(this->status_lock);
     this->status = s;
   }
   multi_batch.pending_wb_cnt.fetch_sub(1, std::memory_order_acq_rel);

--- a/db/write_thread.h
+++ b/db/write_thread.h
@@ -25,6 +25,7 @@
 #include "rocksdb/types.h"
 #include "rocksdb/write_batch.h"
 #include "util/autovector.h"
+#include "util/mutexlock.h"
 
 namespace ROCKSDB_NAMESPACE {
 
@@ -190,7 +191,8 @@ class WriteThread {
     WriteGroup* write_group;
     CommitRequest* request;
     SequenceNumber sequence;  // the sequence number to use for the first key
-    Status status;
+    Status status;  // write protected by status_lock in multi batch write.
+    SpinMutex status_lock;
     Status callback_status;  // status returned by callback->Callback()
 
     std::aligned_storage<sizeof(std::mutex)>::type state_mutex_bytes;


### PR DESCRIPTION
* Fix SIGABRT caused by uninitialized mutex

Signed-off-by: Wenbo Zhang <ethercflow@gmail.com>

* Use spinlock instead of mutex to reduce writer ctor cost

Signed-off-by: Wenbo Zhang <ethercflow@gmail.com>

* Update db/write_thread.h

Co-authored-by: Xinye Tao <xy.tao@outlook.com>
Signed-off-by: Wenbo Zhang <ethercflow@gmail.com>

Co-authored-by: Xinye Tao <xy.tao@outlook.com>