### PR TITLE
Check OPENSSL_NO_SM4 before using sm4 encryption

### DIFF
--- a/encryption/encryption.cc
+++ b/encryption/encryption.cc
@@ -215,7 +215,7 @@ Status NewAESCTRCipherStream(EncryptionMethod method, const std::string& key,
       cipher = EVP_aes_256_ctr();
       break;
     case EncryptionMethod::kSM4_CTR:
-#if OPENSSL_VERSION_NUMBER < 0x1010100fL
+#if OPENSSL_VERSION_NUMBER < 0x1010100fL || defined(OPENSSL_NO_SM4)
       return Status::InvalidArgument(
           "Unsupport SM4 encryption method under OpenSSL version: " +
           std::string(OPENSSL_VERSION_TEXT));

--- a/encryption/encryption.h
+++ b/encryption/encryption.h
@@ -59,7 +59,7 @@ class AESCTRCipherStream : public BlockAccessCipherStream {
 
   size_t BlockSize() override {
     // Openssl support SM4 after 1.1.1 release version.
-#if OPENSSL_VERSION_NUMBER >= 0x1010100fL
+#if OPENSSL_VERSION_NUMBER >= 0x1010100fL && !defined(OPENSSL_NO_SM4)
     if (EVP_CIPHER_nid(cipher_) == NID_sm4_ctr) {
       return SM4_BLOCK_SIZE;
     }

--- a/encryption/encryption_test.cc
+++ b/encryption/encryption_test.cc
@@ -56,7 +56,7 @@ class EncryptionTest
       case EncryptionMethod::kAES256_CTR:
         cipher = EVP_aes_256_ctr();
         break;
-#if OPENSSL_VERSION_NUMBER >= 0x1010100fL
+#if OPENSSL_VERSION_NUMBER >= 0x1010100fL && !defined(OPENSSL_NO_SM4)
       // Openssl support SM4 after 1.1.1 release version.
       case EncryptionMethod::kSM4_CTR:
         cipher = EVP_sm4_ctr();
@@ -153,7 +153,7 @@ TEST_P(EncryptionTest, EncryptionTest) {
 }
 
 // Openssl support SM4 after 1.1.1 release version.
-#if OPENSSL_VERSION_NUMBER < 0x1010100fL
+#if OPENSSL_VERSION_NUMBER < 0x1010100fL || defined(OPENSSL_NO_SM4)
 INSTANTIATE_TEST_CASE_P(
     EncryptionTestInstance, EncryptionTest,
     testing::Combine(testing::Bool(),


### PR DESCRIPTION
In some env, user installed openssl by `yum install`, and the openssl software may complied with `OPENSSL_NO_SM4` flag, so although the version is >= 1.1.1, but we still could not use sm4 in that situation.

Signed-off-by: Jarvis Zheng <jiayang@hust.edu.cn>