### PR TITLE
Add encryption test

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1984,7 +1984,7 @@ db_basic_bench: $(OBJ_DIR)/microbench/db_basic_bench.o $(LIBRARY)
 cache_reservation_manager_test: $(OBJ_DIR)/cache/cache_reservation_manager_test.o $(TEST_LIBRARY) $(LIBRARY)
 	$(AM_LINK)
 
-encryption_test: encryption/encryption_test.o $(LIBOBJECTS) $(TESTHARNESS)
+encryption_test: $(OBJ_DIR)/encryption/encryption_test.o $(TEST_LIBRARY) $(LIBRARY)
 	$(AM_LINK)
 
 #-------------------------------------------------

--- a/TARGETS
+++ b/TARGETS
@@ -1574,6 +1574,13 @@ ROCKS_TESTS = [
         [],
     ],
     [
+        "encryption_test",
+        "encryption/encryption_test.cc",
+        "parallel",
+        [],
+        [],
+    ],
+    [
         "env_basic_test",
         "env/env_basic_test.cc",
         "parallel",

--- a/src.mk
+++ b/src.mk
@@ -495,6 +495,7 @@ TEST_MAIN_SOURCES =                                                     \
   db/write_batch_test.cc                                                \
   db/write_callback_test.cc                                             \
   db/write_controller_test.cc                                           \
+  encryption/encryption_test.cc                                         \
   env/env_basic_test.cc                                                 \
   env/env_test.cc                                                       \
   env/io_posix_test.cc                                                  \


### PR DESCRIPTION
In [PR#6660](https://github.com/facebook/rocksdb/pull/6660/files) ,  Makefile is adjusted, but encryption_test is sorted out.
Add the adjustment for encryption_test.

Signed-off-by: Jarvis Zheng <zhengjiayang@pingcap.com>