### PR TITLE
Suppress false positive warnings on GCC 12

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -532,6 +532,9 @@ endif()
 
 if(CMAKE_COMPILER_IS_GNUCXX)
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fno-builtin-memcmp")
+  # GCC 12 outputs too many false positive array-bounds warnings. Suppress it
+  # until fixed by the compiler.
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-array-bounds")
 endif()
 
 option(ROCKSDB_LITE "Build RocksDBLite version" OFF)

--- a/trace_replay/trace_replay.cc
+++ b/trace_replay/trace_replay.cc
@@ -317,7 +317,7 @@ Status TracerHelper::DecodeTraceRecord(Trace* trace, int trace_file_version,
       cf_ids.reserve(multiget_size);
       multiget_keys.reserve(multiget_size);
       for (uint32_t i = 0; i < multiget_size; i++) {
-        uint32_t tmp_cfid;
+        uint32_t tmp_cfid = 0;
         Slice tmp_key;
         GetFixed32(&cfids_payload, &tmp_cfid);
         GetLengthPrefixedSlice(&keys_payload, &tmp_key);


### PR DESCRIPTION
GCC 12 complains about `vector.push_back()`. It apparently looks like a false positive warning. I cannot understand the reason at all. Let's just ignore the warning for now.

```
In file included from /usr/include/c++/12.1.0/vector:64,
                 from /rocksdb/db/memtable_list.h:13,
                 from /rocksdb/db/memtable_list.cc:6:
In member function ‘void std::vector<_Tp, _Alloc>::push_back(const value_type&) [with _Tp = rocksdb::MemTable*; _Alloc = std::allocator<rocksdb::MemTable*>]’,
    inlined from ‘void rocksdb::autovector<T, kSize>::push_back(const T&) [with T = rocksdb::MemTable*; long unsigned int kSize = 8]’ at /rocksdb/util/autovector.h:286:22,
    inlined from ‘void rocksdb::MemTableListVersion::UnrefMemTable(rocksdb::autovector<rocksdb::MemTable*>*, rocksdb::MemTable*)’ at /rocksdb/db/memtable_list.cc:42:25,
    inlined from ‘void rocksdb::MemTableListVersion::Unref(rocksdb::autovector<rocksdb::MemTable*>*)’ at /rocksdb/db/memtable_list.cc:88:20,
    inlined from ‘void rocksdb::MemTableListVersion::Unref(rocksdb::autovector<rocksdb::MemTable*>*)’ at /rocksdb/db/memtable_list.cc:77:6,
    inlined from ‘void rocksdb::MemTableList::InstallNewVersion()’ at /rocksdb/db/memtable_list.cc:638:19:
/usr/include/c++/12.1.0/bits/stl_vector.h:1278:27: error: array subscript 0 is outside array bounds of ‘std::vector<rocksdb::MemTable*, std::allocator<rocksdb::MemTable*> > [0]’ [-Werror=array-bounds]
 1278 |         if (this->_M_impl._M_finish != this->_M_impl._M_end_of_storage)
      |             ~~~~~~~~~~~~~~^~~~~~~~~
/usr/include/c++/12.1.0/bits/stl_vector.h:1278:54: error: array subscript 0 is outside array bounds of ‘std::vector<rocksdb::MemTable*, std::allocator<rocksdb::MemTable*> > [0]’ [-Werror=array-bounds]
 1278 |         if (this->_M_impl._M_finish != this->_M_impl._M_end_of_storage)
      |                                        ~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~
/usr/include/c++/12.1.0/bits/stl_vector.h:1283:13: error: array subscript 0 is outside array bounds of ‘std::vector<rocksdb::MemTable*, std::allocator<rocksdb::MemTable*> > [0]’ [-Werror=array-bounds]
 1283 |             ++this->_M_impl._M_finish;
      |             ^~
In member function ‘void std::vector<_Tp, _Alloc>::push_back(const value_type&) [with _Tp = rocksdb::MemTable*; _Alloc = std::allocator<rocksdb::MemTable*>]’,
    inlined from ‘void rocksdb::autovector<T, kSize>::push_back(const T&) [with T = rocksdb::MemTable*; long unsigned int kSize = 8]’ at /rocksdb/util/autovector.h:286:22,
    inlined from ‘void rocksdb::MemTableListVersion::UnrefMemTable(rocksdb::autovector<rocksdb::MemTable*>*, rocksdb::MemTable*)’ at /rocksdb/db/memtable_list.cc:42:25,
    inlined from ‘void rocksdb::MemTableListVersion::Unref(rocksdb::autovector<rocksdb::MemTable*>*)’ at /rocksdb/db/memtable_list.cc:85:20,
    inlined from ‘void rocksdb::MemTableListVersion::Unref(rocksdb::autovector<rocksdb::MemTable*>*)’ at /rocksdb/db/memtable_list.cc:77:6,
    inlined from ‘void rocksdb::MemTableList::InstallNewVersion()’ at /rocksdb/db/memtable_list.cc:638:19:
/usr/include/c++/12.1.0/bits/stl_vector.h:1278:27: error: array subscript 0 is outside array bounds of ‘std::vector<rocksdb::MemTable*, std::allocator<rocksdb::MemTable*> > [0]’ [-Werror=array-bounds]
 1278 |         if (this->_M_impl._M_finish != this->_M_impl._M_end_of_storage)
      |             ~~~~~~~~~~~~~~^~~~~~~~~
/usr/include/c++/12.1.0/bits/stl_vector.h:1278:54: error: array subscript 0 is outside array bounds of ‘std::vector<rocksdb::MemTable*, std::allocator<rocksdb::MemTable*> > [0]’ [-Werror=array-bounds]
 1278 |         if (this->_M_impl._M_finish != this->_M_impl._M_end_of_storage)
      |                                        ~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~
/usr/include/c++/12.1.0/bits/stl_vector.h:1283:13: error: array subscript 0 is outside array bounds of ‘std::vector<rocksdb::MemTable*, std::allocator<rocksdb::MemTable*> > [0]’ [-Werror=array-bounds]
 1283 |             ++this->_M_impl._M_finish;
      |             ^~
```

The other diff is because GCC thinks `tmp_cfid` is potentially uninitialized. I simply initialize it to resolve it.