### PR TITLE
fix writing empty batch in multi-batch mode

### DIFF
--- a/db/db_impl/db_impl_write.cc
+++ b/db/db_impl/db_impl_write.cc
@@ -235,10 +235,10 @@ Status DBImpl::MultiBatchWriteImpl(const WriteOptions& write_options,
                   write_options.ignore_missing_column_families, this);
               w->request->commit_lsn = next_sequence + count - 1;
               write_thread_.EnterCommitQueue(w->request);
+              next_sequence += count;
+              total_count += count;
+              memtable_write_cnt++;
             }
-            next_sequence += count;
-            total_count += count;
-            memtable_write_cnt++;
           }
           total_byte_size = WriteBatchInternal::AppendedByteSize(
               total_byte_size,


### PR DESCRIPTION
In this line, `memtable_write_cnt` is incremented regardless of whether the write batch is empty.
https://github.com/tikv/rocksdb/blob/98a80e979bf1554823b0340dc2873633069ec16a/db/db_impl/db_impl_write.cc#L241

It's then added to the global `pending_memtable_writes_` counter:
https://github.com/tikv/rocksdb/blob/98a80e979bf1554823b0340dc2873633069ec16a/db/db_impl/db_impl_write.cc#L297

However, when it's empty, the `request` won't be enqueued to the commit queue, and the counter will never be decremented properly here:
https://github.com/tikv/rocksdb/blob/98a80e979bf1554823b0340dc2873633069ec16a/db/db_impl/db_impl_write.cc#L123-L125

As a result, a later write will potentially block on `WaitForPendingWrites` forever.

Signed-off-by: tabokie <xy.tao@outlook.com>