### PR TITLE
Revert write memtable opt

### DIFF
--- a/db/column_family.cc
+++ b/db/column_family.cc
@@ -1205,7 +1205,7 @@ Status ColumnFamilyData::ValidateOptions(
     }
   }
 
-  if (db_options.enable_multi_batch_write &&
+  if (db_options.enable_pipelined_commit &&
       cf_options.max_successive_merges > 0) {
     return Status::NotSupported(
         "Multi thread write is only supported with no successive merges");

--- a/db/db_impl/db_impl_open.cc
+++ b/db/db_impl/db_impl_open.cc
@@ -123,10 +123,10 @@ DBOptions SanitizeOptions(const std::string& dbname, const DBOptions& src) {
 
   // multi thread write do not support two-write-que or write in 2PC
   if (result.two_write_queues || result.allow_2pc) {
-    result.enable_multi_batch_write = false;
+    result.enable_pipelined_commit = false;
   }
 
-  if (result.enable_multi_batch_write) {
+  if (result.enable_pipelined_commit) {
     result.enable_pipelined_write = false;
     result.allow_concurrent_memtable_write = true;
   }
@@ -873,7 +873,7 @@ Status DBImpl::RecoverLogFiles(const std::vector<uint64_t>& log_numbers,
       bool has_valid_writes = false;
       status = WriteBatchInternal::InsertInto(
           &batch, column_family_memtables_.get(), &flush_scheduler_, true,
-          log_number, 0, this, false /* concurrent_memtable_writes */,
+          log_number, this, false /* concurrent_memtable_writes */,
           next_sequence, &has_valid_writes, seq_per_batch_, batch_per_txn_);
       MaybeIgnoreError(&status);
       if (!status.ok()) {

--- a/db/db_impl/db_impl_secondary.cc
+++ b/db/db_impl/db_impl_secondary.cc
@@ -253,7 +253,7 @@ Status DBImplSecondary::RecoverLogFiles(
         bool has_valid_writes = false;
         status = WriteBatchInternal::InsertInto(
             &batch, column_family_memtables_.get(),
-            nullptr /* flush_scheduler */, true, log_number, 0, this,
+            nullptr /* flush_scheduler */, true, log_number, this,
             false /* concurrent_memtable_writes */, next_sequence,
             &has_valid_writes, seq_per_batch_, batch_per_txn_);
       }

--- a/db/db_properties_test.cc
+++ b/db/db_properties_test.cc
@@ -37,7 +37,7 @@ TEST_F(DBPropertiesTest, Empty) {
     options.write_buffer_size = 100000;  // Small write buffer
     options.allow_concurrent_memtable_write = false;
     options = CurrentOptions(options);
-    if (options.enable_multi_batch_write) {
+    if (options.enable_pipelined_commit) {
       continue;
     }
     CreateAndReopenWithCF({"pikachu"}, options);

--- a/db/db_test_util.cc
+++ b/db/db_test_util.cc
@@ -555,8 +555,8 @@ Options DBTestBase::GetOptions(
       options.enable_pipelined_write = true;
       break;
     }
-    case kMultiBatchWrite: {
-      options.enable_multi_batch_write = true;
+    case kCommitPipeline: {
+      options.enable_pipelined_commit = true;
       options.enable_pipelined_write = false;
       options.two_write_queues = false;
       break;

--- a/db/db_test_util.h
+++ b/db/db_test_util.h
@@ -684,7 +684,7 @@ class DBTestBase : public testing::Test {
     kConcurrentSkipList = 28,
     kPipelinedWrite = 29,
     kConcurrentWALWrites = 30,
-    kMultiBatchWrite = 31,
+    kCommitPipeline = 31,
     kDirectIO,
     kLevelSubcompactions,
     kBlockBasedTableWithIndexRestartInterval,

--- a/db/db_write_test.cc
+++ b/db/db_write_test.cc
@@ -185,71 +185,11 @@ TEST_P(DBWriteTest, LockWalInEffect) {
   ASSERT_OK(dbfull()->UnlockWAL());
 }
 
-TEST_P(DBWriteTest, MultiThreadWrite) {
-  Options options = GetOptions();
-  std::unique_ptr<FaultInjectionTestEnv> mock_env(
-      new FaultInjectionTestEnv(env_));
-  if (!options.enable_multi_batch_write) {
-    return;
-  }
-  constexpr int kNumThreads = 4;
-  constexpr int kNumWrite = 4;
-  constexpr int kNumBatch = 8;
-  constexpr int kBatchSize = 16;
-  options.env = mock_env.get();
-  options.write_buffer_size = 1024 * 128;
-  Reopen(options);
-  std::vector<port::Thread> threads;
-  for (int t = 0; t < kNumThreads; t++) {
-    threads.push_back(port::Thread(
-        [&](int index) {
-          WriteOptions opt;
-          std::vector<WriteBatch> data(kNumBatch);
-          for (int j = 0; j < kNumWrite; j++) {
-            std::vector<WriteBatch*> batches;
-            for (int i = 0; i < kNumBatch; i++) {
-              WriteBatch* batch = &data[i];
-              batch->Clear();
-              for (int k = 0; k < kBatchSize; k++) {
-                batch->Put("key_" + ToString(index) + "_" + ToString(j) + "_" +
-                               ToString(i) + "_" + ToString(k),
-                           "value" + ToString(k));
-              }
-              batches.push_back(batch);
-            }
-            dbfull()->MultiBatchWrite(opt, std::move(batches));
-          }
-        },
-        t));
-  }
-  for (int i = 0; i < kNumThreads; i++) {
-    threads[i].join();
-  }
-  ReadOptions opt;
-  for (int t = 0; t < kNumThreads; t++) {
-    std::string value;
-    for (int i = 0; i < kNumWrite; i++) {
-      for (int j = 0; j < kNumBatch; j++) {
-        for (int k = 0; k < kBatchSize; k++) {
-          ASSERT_OK(dbfull()->Get(opt,
-                                  "key_" + ToString(t) + "_" + ToString(i) +
-                                      "_" + ToString(j) + "_" + ToString(k),
-                                  &value));
-          std::string expected_value = "value" + ToString(k);
-          ASSERT_EQ(expected_value, value);
-        }
-      }
-    }
-  }
-
-  Close();
-}
-
 INSTANTIATE_TEST_CASE_P(DBWriteTestInstance, DBWriteTest,
                         testing::Values(DBTestBase::kDefault,
                                         DBTestBase::kConcurrentWALWrites,
                                         DBTestBase::kPipelinedWrite,
-                                        DBTestBase::kMultiBatchWrite));
+                                        DBTestBase::kCommitPipeline));
 
 }  // namespace rocksdb
 

--- a/db/write_batch_internal.h
+++ b/db/write_batch_internal.h
@@ -183,8 +183,7 @@ class WriteBatchInternal {
       const WriteBatch* batch, ColumnFamilyMemTables* memtables,
       FlushScheduler* flush_scheduler,
       bool ignore_missing_column_families = false, uint64_t log_number = 0,
-      uint64_t log_ref = 0, DB* db = nullptr,
-      bool concurrent_memtable_writes = false,
+      DB* db = nullptr, bool concurrent_memtable_writes = false,
       SequenceNumber* next_seq = nullptr, bool* has_valid_writes = nullptr,
       bool seq_per_batch = false, bool batch_per_txn = true);
 

--- a/db/write_callback_test.cc
+++ b/db/write_callback_test.cc
@@ -145,7 +145,7 @@ TEST_F(WriteCallbackTest, WriteWithCallbackTest) {
               if (options.enable_pipelined_write && options.two_write_queues) {
                 continue;
               }
-              if (options.enable_multi_batch_write && options.two_write_queues) {
+              if (options.enable_pipelined_commit && options.two_write_queues) {
                 continue;
               }
 
@@ -156,7 +156,7 @@ TEST_F(WriteCallbackTest, WriteWithCallbackTest) {
               if (options.unordered_write && options.enable_pipelined_write) {
                 continue;
               }
-              if (options.unordered_write && options.enable_multi_batch_write) {
+              if (options.unordered_write && options.enable_pipelined_commit) {
                 continue;
               }
 

--- a/db/write_thread.cc
+++ b/db/write_thread.cc
@@ -825,7 +825,7 @@ void WriteThread::Writer::ConsumeOne(size_t claimed) {
       multi_batch.ignore_missing_column_families, 0, this->log_ref,
       multi_batch.db, true);
   if (!s.ok()) {
-    std::lock_guard<SpinMutex> guard(this->status_lock);
+    std::lock_guard<std::mutex> guard(this->StateMutex());
     this->status = s;
   }
   multi_batch.pending_wb_cnt.fetch_sub(1, std::memory_order_acq_rel);

--- a/db/write_thread.cc
+++ b/db/write_thread.cc
@@ -367,7 +367,7 @@ void WriteThread::EndWriteStall() {
 static WriteThread::AdaptationContext jbg_ctx("JoinBatchGroup");
 void WriteThread::JoinBatchGroup(Writer* w) {
   TEST_SYNC_POINT_CALLBACK("WriteThread::JoinBatchGroup:Start", w);
-  assert(!w->multi_batch.batches.empty());
+  assert(w->batch != nullptr);
 
   bool linked_as_leader = LinkOne(w, &newest_writer_);
 
@@ -402,10 +402,10 @@ void WriteThread::JoinBatchGroup(Writer* w) {
 size_t WriteThread::EnterAsBatchGroupLeader(Writer* leader,
                                             WriteGroup* write_group) {
   assert(leader->link_older == nullptr);
-  assert(!leader->multi_batch.batches.empty());
+  assert(leader->batch != nullptr);
   assert(write_group != nullptr);
 
-  size_t size = WriteBatchInternal::ByteSize(leader->multi_batch.batches);
+  size_t size = WriteBatchInternal::ByteSize(leader->batch);
 
   // Allow the group to grow up to a maximum size, but if the
   // original write is small, limit the growth so we do not slow
@@ -451,7 +451,7 @@ size_t WriteThread::EnterAsBatchGroupLeader(Writer* leader,
       break;
     }
 
-    if (w->multi_batch.batches.empty()) {
+    if (w->batch == nullptr) {
       // Do not include those writes with nullptr batch. Those are not writes,
       // those are something else. They want to be alone
       break;
@@ -462,7 +462,7 @@ size_t WriteThread::EnterAsBatchGroupLeader(Writer* leader,
       break;
     }
 
-    auto batch_size = WriteBatchInternal::ByteSize(w->multi_batch.batches);
+    auto batch_size = WriteBatchInternal::ByteSize(w->batch);
     if (size + batch_size > max_size) {
       // Do not make batch too big
       break;
@@ -482,10 +482,10 @@ void WriteThread::EnterAsMemTableWriter(Writer* leader,
                                         WriteGroup* write_group) {
   assert(leader != nullptr);
   assert(leader->link_older == nullptr);
-  assert(!leader->multi_batch.batches.empty());
+  assert(leader->batch != nullptr);
   assert(write_group != nullptr);
 
-  size_t size = WriteBatchInternal::ByteSize(leader->multi_batch.batches);
+  size_t size = WriteBatchInternal::ByteSize(leader->batch);
 
   // Allow the group to grow up to a maximum size, but if the
   // original write is small, limit the growth so we do not slow
@@ -500,7 +500,7 @@ void WriteThread::EnterAsMemTableWriter(Writer* leader,
   write_group->size = 1;
   Writer* last_writer = leader;
 
-  if (!allow_concurrent_memtable_write_ || !leader->multi_batch.batches[0]->HasMerge()) {
+  if (!allow_concurrent_memtable_write_ || !leader->batch->HasMerge()) {
     Writer* newest_writer = newest_memtable_writer_.load();
     CreateMissingNewerLinks(newest_writer);
 
@@ -508,16 +508,16 @@ void WriteThread::EnterAsMemTableWriter(Writer* leader,
     while (w != newest_writer) {
       w = w->link_newer;
 
-      if (w->multi_batch.batches.empty()) {
+      if (w->batch == nullptr) {
         break;
       }
 
-      if (w->multi_batch.batches[0]->HasMerge()) {
+      if (w->batch->HasMerge()) {
         break;
       }
 
       if (!allow_concurrent_memtable_write_) {
-        auto batch_size = WriteBatchInternal::ByteSize(w->multi_batch.batches);
+        auto batch_size = WriteBatchInternal::ByteSize(w->batch);
         if (size + batch_size > max_size) {
           // Do not make batch too big
           break;
@@ -532,9 +532,8 @@ void WriteThread::EnterAsMemTableWriter(Writer* leader,
   }
 
   write_group->last_writer = last_writer;
-  write_group->last_sequence = last_writer->sequence +
-                               WriteBatchInternal::Count(last_writer->multi_batch.batches) -
-                               1;
+  write_group->last_sequence =
+      last_writer->sequence + WriteBatchInternal::Count(last_writer->batch) - 1;
 }
 
 void WriteThread::ExitAsMemTableWriter(Writer* /*self*/,
@@ -730,7 +729,7 @@ void WriteThread::ExitAsBatchGroupLeader(WriteGroup& write_group,
 
 static WriteThread::AdaptationContext eu_ctx("EnterUnbatched");
 void WriteThread::EnterUnbatched(Writer* w, InstrumentedMutex* mu) {
-  assert(w != nullptr && w->multi_batch.batches.empty());
+  assert(w != nullptr && w->batch == nullptr);
   mu->Unlock();
   bool linked_as_leader = LinkOne(w, &newest_writer_);
   if (!linked_as_leader) {
@@ -782,32 +781,13 @@ void RequestQueue::CommitSequenceAwait(CommitRequest* req,
                                        std::atomic<uint64_t>* commit_sequence) {
   std::unique_lock<std::mutex> guard(commit_mu_);
   while (!requests_.empty() && requests_.front() != req && !req->committed) {
-    // When the subsequent commit finds that the front writer has not yet
-    // submitted, it will help the front writer to perform some tasks
-    auto front = requests_.front()->writer;
-    if (front->ConsumableOnOtherThreads()) {
-      auto claimed = front->Claim();
-      if (claimed < front->multi_batch.batches.size()) {
-        guard.unlock();
-        front->ConsumeOne(claimed);
-        guard.lock();
-        continue;
-      }
-    } else {
-      // The front writer may be waiting for this helper writer
-      commit_cv_.notify_all();
-    }
     commit_cv_.wait(guard);
   }
   if (req->committed) {
     return;
   } else if (requests_.front() == req) {
-    // As the front writer, some write tasks can be stolen by other writers.
-    // Wait for them to finish.
-    while (req->writer->HasPendingWB()) {
-      commit_cv_.wait(guard);
-    }
-    while (!requests_.empty() && !requests_.front()->writer->HasPendingWB()) {
+    while (!requests_.empty() &&
+           requests_.front()->applied.load(std::memory_order_acquire)) {
       CommitRequest* current = requests_.front();
       commit_sequence->store(current->commit_lsn, std::memory_order_release);
       current->committed = true;
@@ -815,20 +795,6 @@ void RequestQueue::CommitSequenceAwait(CommitRequest* req,
     }
     commit_cv_.notify_all();
   }
-}
-
-void WriteThread::Writer::ConsumeOne(size_t claimed) {
-  assert(claimed < multi_batch.batches.size());
-  ColumnFamilyMemTablesImpl memtables(multi_batch.version_set);
-  Status s = WriteBatchInternal::InsertInto(
-      multi_batch.batches[claimed], &memtables, multi_batch.flush_scheduler,
-      multi_batch.ignore_missing_column_families, 0, this->log_ref,
-      multi_batch.db, true);
-  if (!s.ok()) {
-    std::lock_guard<std::mutex> guard(this->StateMutex());
-    this->status = s;
-  }
-  multi_batch.pending_wb_cnt.fetch_sub(1, std::memory_order_acq_rel);
 }
 
 }  // namespace rocksdb

--- a/db/write_thread.h
+++ b/db/write_thread.h
@@ -28,11 +28,14 @@
 #include "util/autovector.h"
 
 namespace rocksdb {
-
-struct CommitRequest;
-
-class ColumnFamilySet;
-class FlushScheduler;
+struct CommitRequest {
+  uint64_t commit_lsn;
+  // We use applied to check whether this writer has applied to memtable.
+  std::atomic<bool> applied;
+  // protected by RequestQueue::commit_mu_
+  bool committed;
+  CommitRequest() : commit_lsn(0), applied(false), committed(false) {}
+};
 
 class RequestQueue {
  public:
@@ -133,43 +136,9 @@ class WriteThread {
     Iterator end() const { return Iterator(nullptr, nullptr); }
   };
 
-  struct MultiBatch {
-    std::vector<WriteBatch*> batches;
-    std::atomic<size_t> claimed_cnt;
-    std::atomic<size_t> pending_wb_cnt;
-    ColumnFamilySet* version_set;
-    FlushScheduler* flush_scheduler;
-    bool ignore_missing_column_families;
-    DB *db;
-
-    MultiBatch()
-        : claimed_cnt(0),
-          pending_wb_cnt(0),
-          version_set(nullptr),
-          flush_scheduler(nullptr),
-          ignore_missing_column_families(false),
-          db(nullptr) {}
-
-    explicit MultiBatch(std::vector<WriteBatch*>&& _batch)
-        : batches(_batch),
-          claimed_cnt(0),
-          pending_wb_cnt(_batch.size()),
-          version_set(nullptr),
-          flush_scheduler(nullptr),
-          ignore_missing_column_families(false),
-          db(nullptr) {}
-
-    void SetContext(ColumnFamilySet* _version_set, FlushScheduler* _flush_scheduler,
-                    bool _ignore_missing_column_families, DB* _db) {
-      version_set = _version_set;
-      flush_scheduler = _flush_scheduler;
-      ignore_missing_column_families = _ignore_missing_column_families;
-      db = _db;
-    }
-  };
-
   // Information kept for every waiting writer.
   struct Writer {
+    WriteBatch* batch;
     bool sync;
     bool no_slowdown;
     bool disable_wal;
@@ -192,10 +161,9 @@ class WriteThread {
     Writer* link_older;  // read/write only before linking, or as leader
     Writer* link_newer;  // lazy, read/write only before linking, or as leader
 
-    MultiBatch multi_batch;
-
     Writer()
-        : sync(false),
+        : batch(nullptr),
+          sync(false),
           no_slowdown(false),
           disable_wal(false),
           disable_memtable(false),
@@ -216,7 +184,8 @@ class WriteThread {
            WriteCallback* _callback, uint64_t _log_ref, bool _disable_memtable,
            size_t _batch_cnt = 0,
            PreReleaseCallback* _pre_release_callback = nullptr)
-        : sync(write_options.sync),
+        : batch(_batch),
+          sync(write_options.sync),
           no_slowdown(write_options.no_slowdown),
           disable_wal(write_options.disableWAL),
           disable_memtable(_disable_memtable),
@@ -231,31 +200,7 @@ class WriteThread {
           request(nullptr),
           sequence(kMaxSequenceNumber),
           link_older(nullptr),
-          link_newer(nullptr) {
-      multi_batch.batches.push_back(_batch);
-      multi_batch.pending_wb_cnt.fetch_add(1, std::memory_order_acq_rel);
-    }
-
-    Writer(const WriteOptions& write_options, std::vector<WriteBatch*>&& _batch,
-           WriteCallback* _callback, uint64_t _log_ref, bool _disable_memtable,
-           PreReleaseCallback* _pre_release_callback = nullptr)
-        : sync(write_options.sync),
-          no_slowdown(write_options.no_slowdown),
-          disable_wal(write_options.disableWAL),
-          disable_memtable(_disable_memtable),
-          batch_cnt(0),
-          pre_release_callback(_pre_release_callback),
-          log_used(0),
-          log_ref(_log_ref),
-          callback(_callback),
-          made_waitable(false),
-          state(STATE_INIT),
-          write_group(nullptr),
-          request(nullptr),
-          sequence(kMaxSequenceNumber),
-          link_older(nullptr),
-          link_newer(nullptr),
-          multi_batch(std::move(_batch)) {}
+          link_newer(nullptr) {}
 
     ~Writer() {
       if (made_waitable) {
@@ -326,33 +271,6 @@ class WriteThread {
       return *static_cast<std::condition_variable*>(
                  static_cast<void*>(&state_cv_bytes));
     }
-
-    bool ConsumableOnOtherThreads() {
-      return multi_batch.pending_wb_cnt.load(std::memory_order_acquire) > 1;
-    }
-
-    size_t Claim() {
-      return multi_batch.claimed_cnt.fetch_add(1, std::memory_order_acq_rel);
-    }
-
-    bool HasPendingWB() {
-      return multi_batch.pending_wb_cnt.load(std::memory_order_acquire) > 0;
-    }
-
-    void ResetPendingWBCnt() {
-      multi_batch.pending_wb_cnt.store(0, std::memory_order_release);
-    }
-
-    bool ConsumeOne() {
-      auto claimed = Claim();
-      if (claimed < multi_batch.batches.size()) {
-        ConsumeOne(claimed);
-        return true;
-      }
-      return false;
-    }
-
-    void ConsumeOne(size_t claimed);
   };
 
   struct AdaptationContext {
@@ -539,14 +457,6 @@ class WriteThread {
   // Set a follower in write_group to completed state and remove it from the
   // write group.
   void CompleteFollower(Writer* w, WriteGroup& write_group);
-};
-
-struct CommitRequest {
-  WriteThread::Writer* writer;
-  uint64_t commit_lsn;
-  // protected by RequestQueue::commit_mu_
-  bool committed;
-  CommitRequest(WriteThread::Writer* w) : writer(w), commit_lsn(0), committed(false) {}
 };
 
 }  // namespace rocksdb

--- a/db/write_thread.h
+++ b/db/write_thread.h
@@ -26,7 +26,6 @@
 #include "rocksdb/types.h"
 #include "rocksdb/write_batch.h"
 #include "util/autovector.h"
-#include "util/mutexlock.h"
 
 namespace rocksdb {
 
@@ -185,8 +184,7 @@ class WriteThread {
     WriteGroup* write_group;
     CommitRequest* request;
     SequenceNumber sequence;  // the sequence number to use for the first key
-    Status status;  // write protected by status_lock in multi batch write.
-    SpinMutex status_lock;
+    Status status;
     Status callback_status;   // status returned by callback->Callback()
 
     std::aligned_storage<sizeof(std::mutex)>::type state_mutex_bytes;

--- a/include/rocksdb/db.h
+++ b/include/rocksdb/db.h
@@ -384,11 +384,6 @@ class DB {
     return Write(options, updates, nullptr);
   }
 
-  virtual Status MultiBatchWrite(const WriteOptions& /*options*/,
-                                 std::vector<WriteBatch*>&& /*updates*/) {
-    return Status::NotSupported();
-  }
-
   // If the database contains an entry for "key" store the
   // corresponding value in *value and return OK.
   //

--- a/include/rocksdb/options.h
+++ b/include/rocksdb/options.h
@@ -966,16 +966,11 @@ struct DBOptions {
   // to the head of the queue becomes write batch group leader and responsible
   // for writing to WAL.
   //
-  // If enable_multi_batch_write is true, RocksDB will apply WriteBatch to
-  // memtable out of order but commit them in order. (We borrow the idea from
-  // https://github.com/cockroachdb/pebble/blob/master/docs/rocksdb.md#commit-pipeline.
-  // On this basis, we split the WriteBatch into smaller-grained WriteBatch vector,
-  // and when the WriteBatch sizes of multiple writers are not balanced, writers
-  // that finish first need to help the front writer finish writing the remaining
-  // WriteBatch to increase cpu usage and reduce overall latency).
+  // If enable_pipelined_commit is true, RocksDB will apply WriteBatch to
+  // memtable out of order but commit them in order.
   //
   // Default: false
-  bool enable_multi_batch_write = false;
+  bool enable_pipelined_commit = false;
 
   // If true, allow multi-writers to update mem tables in parallel.
   // Only some memtable_factory-s support concurrent writes; currently it

--- a/options/db_options.cc
+++ b/options/db_options.cc
@@ -62,7 +62,7 @@ ImmutableDBOptions::ImmutableDBOptions(const DBOptions& options)
       enable_thread_tracking(options.enable_thread_tracking),
       enable_pipelined_write(options.enable_pipelined_write),
       unordered_write(options.unordered_write),
-      enable_multi_batch_write(options.enable_multi_batch_write),
+      enable_pipelined_commit(options.enable_pipelined_commit),
       allow_concurrent_memtable_write(options.allow_concurrent_memtable_write),
       enable_write_thread_adaptive_yield(
           options.enable_write_thread_adaptive_yield),
@@ -180,8 +180,8 @@ void ImmutableDBOptions::Dump(Logger* log) const {
                    enable_pipelined_write);
   ROCKS_LOG_HEADER(log, "                 Options.unordered_write: %d",
                    unordered_write);
-  ROCKS_LOG_HEADER(log, "              Options.enable_multi_batch_write: %d",
-                   enable_multi_batch_write);
+  ROCKS_LOG_HEADER(log, "              Options.enable_pipelined_commit: %d",
+                   enable_pipelined_commit);
   ROCKS_LOG_HEADER(log, "        Options.allow_concurrent_memtable_write: %d",
                    allow_concurrent_memtable_write);
   ROCKS_LOG_HEADER(log, "     Options.enable_write_thread_adaptive_yield: %d",

--- a/options/db_options.h
+++ b/options/db_options.h
@@ -59,7 +59,7 @@ struct ImmutableDBOptions {
   bool enable_thread_tracking;
   bool enable_pipelined_write;
   bool unordered_write;
-  bool enable_multi_batch_write;
+  bool enable_pipelined_commit;
   bool allow_concurrent_memtable_write;
   bool enable_write_thread_adaptive_yield;
   uint64_t write_thread_max_yield_usec;

--- a/options/options_helper.cc
+++ b/options/options_helper.cc
@@ -105,8 +105,8 @@ DBOptions BuildDBOptions(const ImmutableDBOptions& immutable_db_options,
   options.enable_thread_tracking = immutable_db_options.enable_thread_tracking;
   options.delayed_write_rate = mutable_db_options.delayed_write_rate;
   options.enable_pipelined_write = immutable_db_options.enable_pipelined_write;
-  options.enable_multi_batch_write =
-      immutable_db_options.enable_multi_batch_write;
+  options.enable_pipelined_commit =
+      immutable_db_options.enable_pipelined_commit;
   options.unordered_write = immutable_db_options.unordered_write;
   options.allow_concurrent_memtable_write =
       immutable_db_options.allow_concurrent_memtable_write;
@@ -1601,8 +1601,8 @@ std::unordered_map<std::string, OptionTypeInfo>
         {"enable_pipelined_write",
          {offsetof(struct DBOptions, enable_pipelined_write),
           OptionType::kBoolean, OptionVerificationType::kNormal, false, 0}},
-        {"enable_multi_batch_write",
-         {offsetof(struct DBOptions, enable_multi_batch_write),
+        {"enable_pipelined_commit",
+         {offsetof(struct DBOptions, enable_pipelined_commit),
           OptionType::kBoolean, OptionVerificationType::kNormal, false, 0}},
         {"unordered_write",
          {offsetof(struct DBOptions, unordered_write), OptionType::kBoolean,

--- a/options/options_settable_test.cc
+++ b/options/options_settable_test.cc
@@ -276,7 +276,7 @@ TEST_F(OptionsSettableTest, DBOptionsAllFieldsSettable) {
                              "advise_random_on_open=true;"
                              "fail_if_options_file_error=false;"
                              "enable_pipelined_write=false;"
-                             "enable_multi_batch_write=false;"
+                             "enable_pipelined_commit=false;"
                              "unordered_write=false;"
                              "allow_concurrent_memtable_write=true;"
                              "wal_recovery_mode=kPointInTimeRecovery;"

--- a/table/table_test.cc
+++ b/table/table_test.cc
@@ -1189,7 +1189,7 @@ TEST_F(TablePropertyTest, PrefixScanTest) {
                                 {"num.555.3", "3"}, };
 
   // prefixes that exist
-  for (const std::string prefix : {"num.111", "num.333", "num.555"}) {
+  for (const std::string& prefix : {"num.111", "num.333", "num.555"}) {
     int num = 0;
     for (auto pos = props.lower_bound(prefix);
          pos != props.end() &&
@@ -1204,7 +1204,7 @@ TEST_F(TablePropertyTest, PrefixScanTest) {
   }
 
   // prefixes that don't exist
-  for (const std::string prefix :
+  for (const std::string& prefix :
        {"num.000", "num.222", "num.444", "num.666"}) {
     auto pos = props.lower_bound(prefix);
     ASSERT_TRUE(pos == props.end() ||

--- a/tools/db_bench_tool.cc
+++ b/tools/db_bench_tool.cc
@@ -1251,60 +1251,6 @@ struct ReportFileOpCounters {
   std::atomic<uint64_t> bytes_written_;
 };
 
-class WriteBatchVec {
- public:
-  explicit WriteBatchVec(int max_batch_size)
-      : max_batch_size_(max_batch_size), current_(0) {}
-  ~WriteBatchVec() {
-    for (auto w : batches_) {
-      delete w;
-    }
-  }
-  void Clear() {
-    for (size_t i = 0; i <= current_ && i < batches_.size(); i++) {
-      batches_[i]->Clear();
-    }
-    current_ = 0;
-  }
-
-  Status Put(const Slice& key, const Slice& value) {
-    if (current_ < batches_.size() &&
-        batches_[current_]->Count() < max_batch_size_) {
-      return batches_[current_]->Put(key, value);
-    } else if (current_ + 1 >= batches_.size()) {
-      batches_.push_back(new WriteBatch);
-    }
-    if (current_ + 1 < batches_.size()) {
-      current_ += 1;
-    }
-    return batches_[current_]->Put(key, value);
-  }
-
-  std::vector<WriteBatch*> GetWriteBatch() const {
-    std::vector<WriteBatch*> batches;
-    for (size_t i = 0; i < batches_.size(); i++) {
-      if (i > current_) {
-        break;
-      }
-      batches.push_back(batches_[i]);
-    }
-    return batches;
-  }
-
-  int Count() const {
-    int count = 0;
-    for (size_t i = 0; i <= current_ && i < batches_.size(); i++) {
-      count += batches_[i]->Count();
-    }
-    return count;
-  }
-
- private:
-  int max_batch_size_;
-  size_t current_;
-  std::vector<WriteBatch*> batches_;
-};
-
 // A special Env to records and report file operations in db_bench
 class ReportFileOpEnv : public EnvWrapper {
  public:
@@ -3905,7 +3851,7 @@ class Benchmark {
       DBWithColumnFamilies* db) {
     Status s;
     if (use_multi_write_) {
-      options.enable_multi_batch_write = true;
+      options.enable_pipelined_commit = true;
     }
     // Open with column families if necessary.
     if (FLAGS_num_column_families > 1) {
@@ -4168,7 +4114,6 @@ class Benchmark {
 
     RandomGenerator gen;
     WriteBatch batch;
-    WriteBatchVec batches(32);
     Status s;
     int64_t bytes = 0;
 
@@ -4204,7 +4149,6 @@ class Benchmark {
       size_t id = thread->rand.Next() % num_key_gens;
       DBWithColumnFamilies* db_with_cfh = SelectDBWithCfh(id);
       batch.Clear();
-      batches.Clear();
 
       if (thread->shared->write_rate_limiter.get() != nullptr) {
         thread->shared->write_rate_limiter->Request(
@@ -4218,9 +4162,7 @@ class Benchmark {
       for (int64_t j = 0; j < entries_per_batch_; j++) {
         int64_t rand_num = key_gens[id]->Next();
         GenerateKeyFromInt(rand_num, FLAGS_num, &key);
-        if (use_multi_write_) {
-          batches.Put(key, gen.Generate(value_size_));
-        } else if (use_blob_db_) {
+        if (use_blob_db_) {
 #ifndef ROCKSDB_LITE
           Slice val = gen.Generate(value_size_);
           int ttl = rand() % FLAGS_blob_db_max_ttl_range;
@@ -4286,10 +4228,7 @@ class Benchmark {
           }
         }
       }
-      if (use_multi_write_) {
-        s = db_with_cfh->db->MultiBatchWrite(write_options_,
-                                             batches.GetWriteBatch());
-      } else if (!use_blob_db_) {
+      if (!use_blob_db_) {
         s = db_with_cfh->db->Write(write_options_, &batch);
       }
       thread->stats.FinishedOps(db_with_cfh, db_with_cfh->db,


### PR DESCRIPTION
As Incall 162-aws's result is to use https://github.com/tikv/tikv/pull/13243/commits/8ee3af290b6eb4bdfa98af93e0ff241ce17ba119 listed in https://github.com/tikv/tikv/pull/13243/commits. So need to merge this revert into 6.4.tikv.

