### PR TITLE
Fix warnings under clang-15

### DIFF
--- a/cache/lru_cache.cc
+++ b/cache/lru_cache.cc
@@ -91,7 +91,7 @@ void LRUHandleTable::Resize() {
   std::unique_ptr<LRUHandle* []> new_list {
     new LRUHandle* [size_t{1} << new_length_bits] {}
   };
-  uint32_t count = 0;
+  [[maybe_unused]] uint32_t count = 0;
   for (uint32_t i = 0; i < old_length; i++) {
     LRUHandle* h = list_[i];
     while (h != nullptr) {

--- a/db/version_edit_handler.cc
+++ b/db/version_edit_handler.cc
@@ -26,7 +26,7 @@ void VersionEditHandlerBase::Iterate(log::Reader& reader,
   assert(log_read_status);
   assert(log_read_status->ok());
 
-  size_t recovered_edits = 0;
+  [[maybe_unused]] size_t recovered_edits = 0;
   Status s = Initialize();
   while (reader.LastRecordEnd() < max_manifest_read_size_ && s.ok() &&
          reader.ReadRecord(&record, &scratch) && log_read_status->ok()) {

--- a/db/version_set.cc
+++ b/db/version_set.cc
@@ -3108,13 +3108,9 @@ void VersionStorageInfo::SetFinalized() {
     assert(MaxBytesForLevel(level) >= max_bytes_prev_level);
     max_bytes_prev_level = MaxBytesForLevel(level);
   }
-  int num_empty_non_l0_level = 0;
   for (int level = 0; level < num_levels(); level++) {
     assert(LevelFiles(level).size() == 0 ||
            LevelFiles(level).size() == LevelFilesBrief(level).num_files);
-    if (level > 0 && NumLevelBytes(level) > 0) {
-      num_empty_non_l0_level++;
-    }
     if (LevelFiles(level).size() > 0) {
       assert(level < num_non_empty_levels());
     }

--- a/third-party/folly/folly/Traits.h
+++ b/third-party/folly/folly/Traits.h
@@ -13,7 +13,7 @@ namespace folly {
 #if !defined(_MSC_VER)
 template <class T>
 struct is_trivially_copyable
-    : std::integral_constant<bool, __has_trivial_copy(T)> {};
+    : std::integral_constant<bool, __is_trivially_copyable(T)> {};
 #else
 template <class T>
 using is_trivially_copyable = std::is_trivially_copyable<T>;


### PR DESCRIPTION
I tried to compile tikv with clang-15, but following warnings make it failed. Fix the warnings

```
db/version_set.cc:3111:7: error: variable 'num_empty_non_l0_level' set but not used [-Werror,-Wunused-but-set-variable]
  int num_empty_non_l0_level = 0;
      ^
```

```
  gmake[1]: warning: -jN forced in submake: disabling jobserver mode.
  In file included from /data1/jaysonhuang/rust-rocksdb/librocksdb_sys/rocksdb/third-party/folly/folly/detail/Futex.cpp:6:
  In file included from /data1/jaysonhuang/rust-rocksdb/librocksdb_sys/rocksdb/third-party/folly/folly/detail/Futex.h:96:
  In file included from /data1/jaysonhuang/rust-rocksdb/librocksdb_sys/rocksdb/third-party/folly/folly/detail/Futex-inl.h:9:
  In file included from /data1/jaysonhuang/rust-rocksdb/librocksdb_sys/rocksdb/third-party/folly/folly/synchronization/ParkingLot.h:13:
  In file included from /data1/jaysonhuang/rust-rocksdb/librocksdb_sys/rocksdb/third-party/folly/folly/Indestructible.h:12:
  /data1/jaysonhuang/rust-rocksdb/librocksdb_sys/rocksdb/third-party/folly/folly/Traits.h:16:36: error: builtin __has_trivial_copy is deprecated; use __is_trivially_copyable instead [-Werror,-Wdeprecated-builtins]
      : std::integral_constant<bool, __has_trivial_copy(T)> {};
                                     ^
  1 error generated.
```

```
 gmake[1]: warning: -jN forced in submake: disabling jobserver mode.
  /data1/jaysonhuang/rust-rocksdb/librocksdb_sys/rocksdb/cache/lru_cache.cc:94:12: error: variable 'count' set but not used [-Werror,-Wunused-but-set-variable]
    uint32_t count = 0;
             ^
  1 error generated.
  gmake[4]: *** [CMakeFiles/rocksdb.dir/cache/lru_cache.cc.o] Error 1
  gmake[4]: *** Waiting for unfinished jobs....
  /data1/jaysonhuang/rust-rocksdb/librocksdb_sys/rocksdb/db/version_edit_handler.cc:29:10: error: variable 'recovered_edits' set but not used [-Werror,-Wunused-but-set-variable]
    size_t recovered_edits = 0;
           ^
  1 error generated.
```