### PR TITLE
Revert "offload periodic work (#328)"

### DIFF
--- a/db/db_impl/db_impl.cc
+++ b/db/db_impl/db_impl.cc
@@ -773,17 +773,16 @@ void DBImpl::PrintStatistics() {
 void DBImpl::StartPeriodicWorkScheduler() {
 #ifndef ROCKSDB_LITE
 
-  bool disable_scheduler =
-      immutable_db_options_.disable_periodic_work_scheduler;
 #ifndef NDEBUG
   // It only used by test to disable scheduler
+  bool disable_scheduler = false;
   TEST_SYNC_POINT_CALLBACK(
       "DBImpl::StartPeriodicWorkScheduler:DisableScheduler",
       &disable_scheduler);
-#endif  // !NDEBUG
   if (disable_scheduler) {
     return;
   }
+#endif  // !NDEBUG
 
   {
     InstrumentedMutexLock l(&mutex_);

--- a/db/db_impl/db_impl.h
+++ b/db/db_impl/db_impl.h
@@ -1131,21 +1131,6 @@ class DBImpl : public DB {
   // flush LOG out of application buffer
   void FlushInfoLog();
 
-  Status DoPeriodicWork(PeriodicWorkType type) override {
-    switch (type) {
-      case PeriodicWorkType::kFlushInfoLog:
-        FlushInfoLog();
-        break;
-      case PeriodicWorkType::kDumpStats:
-        DumpStats();
-        break;
-      case PeriodicWorkType::kPersistStats:
-        PersistStats();
-        break;
-    }
-    return Status::OK();
-  }
-
   // Interface to block and signal the DB in case of stalling writes by
   // WriteBufferManager. Each DBImpl object contains ptr to WBMStallInterface.
   // When DB needs to be blocked or signalled by WriteBufferManager,

--- a/include/rocksdb/db.h
+++ b/include/rocksdb/db.h
@@ -1823,15 +1823,6 @@ class DB {
     return Status::NotSupported("GetStatsHistory() is not implemented.");
   }
 
-  enum PeriodicWorkType {
-    kFlushInfoLog = 0,
-    kDumpStats = 1,
-    kPersistStats = 2,
-  };
-  virtual Status DoPeriodicWork(PeriodicWorkType /*type*/) {
-    return Status::NotSupported("DoPeriodicWork() is not implemented.");
-  }
-
 #ifndef ROCKSDB_LITE
   // Make the secondary instance catch up with the primary by tailing and
   // replaying the MANIFEST and WAL of the primary.

--- a/include/rocksdb/options.h
+++ b/include/rocksdb/options.h
@@ -829,10 +829,6 @@ struct DBOptions {
   // NOT SUPPORTED ANYMORE -- this options is no longer used
   bool skip_log_error_on_recovery = false;
 
-  // Disable periodic work scheduler. User should manually run periodic work
-  // with `DB::DoPeriodicWork()`. Default: false
-  bool disable_periodic_work_scheduler = false;
-
   // if not zero, dump rocksdb.stats to LOG every stats_dump_period_sec
   //
   // Default: 600 (10 min)

--- a/options/db_options.cc
+++ b/options/db_options.cc
@@ -541,10 +541,6 @@ static std::unordered_map<std::string, OptionTypeInfo>
          OptionTypeInfo::Enum<CacheTier>(
              offsetof(struct ImmutableDBOptions, lowest_used_cache_tier),
              &cache_tier_string_map, OptionTypeFlags::kNone)},
-        {"disable_periodic_work_scheduler",
-         {offsetof(struct ImmutableDBOptions, disable_periodic_work_scheduler),
-          OptionType::kBoolean, OptionVerificationType::kNormal,
-          OptionTypeFlags::kNone}},
 };
 
 const std::string OptionsHelper::kDBOptionsName = "DBOptions";
@@ -745,8 +741,7 @@ ImmutableDBOptions::ImmutableDBOptions(const DBOptions& options)
       db_host_id(options.db_host_id),
       checksum_handoff_file_types(options.checksum_handoff_file_types),
       lowest_used_cache_tier(options.lowest_used_cache_tier),
-      compaction_service(options.compaction_service),
-      disable_periodic_work_scheduler(options.disable_periodic_work_scheduler) {
+      compaction_service(options.compaction_service) {
   stats = statistics.get();
   fs = env->GetFileSystem();
   if (env != nullptr) {
@@ -924,10 +919,6 @@ void ImmutableDBOptions::Dump(Logger* log) const {
                    allow_data_in_errors);
   ROCKS_LOG_HEADER(log, "            Options.db_host_id: %s",
                    db_host_id.c_str());
-  ROCKS_LOG_HEADER(log,
-                   "                       "
-                   "Options.disable_periodic_work_scheduler: %d",
-                   disable_periodic_work_scheduler);
 }
 
 bool ImmutableDBOptions::IsWalDirSameAsDBPath() const {

--- a/options/db_options.h
+++ b/options/db_options.h
@@ -106,7 +106,6 @@ struct ImmutableDBOptions {
   Statistics* stats;
   Logger* logger;
   std::shared_ptr<CompactionService> compaction_service;
-  bool disable_periodic_work_scheduler;
 
   bool IsWalDirSameAsDBPath() const;
   bool IsWalDirSameAsDBPath(const std::string& path) const;

--- a/options/options_helper.cc
+++ b/options/options_helper.cc
@@ -188,8 +188,6 @@ DBOptions BuildDBOptions(const ImmutableDBOptions& immutable_db_options,
   options.checksum_handoff_file_types =
       immutable_db_options.checksum_handoff_file_types;
   options.lowest_used_cache_tier = immutable_db_options.lowest_used_cache_tier;
-  options.disable_periodic_work_scheduler =
-      immutable_db_options.disable_periodic_work_scheduler;
   return options;
 }
 

--- a/options/options_settable_test.cc
+++ b/options/options_settable_test.cc
@@ -344,8 +344,7 @@ TEST_F(OptionsSettableTest, DBOptionsAllFieldsSettable) {
                              "bgerror_resume_retry_interval=1000000"
                              "db_host_id=hostname;"
                              "lowest_used_cache_tier=kNonVolatileBlockTier;"
-                             "allow_data_in_errors=false;"
-                             "disable_periodic_work_scheduler=false",
+                             "allow_data_in_errors=false",
                              new_options));
 
   ASSERT_EQ(unset_bytes_base, NumUnsetBytes(new_options_ptr, sizeof(DBOptions),


### PR DESCRIPTION
I realized `DumpStats` task dumps private statistics which shouldn't be disabled for multi-rocksdb use case. For `FlushInfoLog` task,   the logger we are using right now has a noop `Flush` implementation. So it should be fine to schedule tasks.