### PR TITLE
exclude uninitialized files when estimating compression ratio

### DIFF
--- a/db/version_set.cc
+++ b/db/version_set.cc
@@ -1571,6 +1571,9 @@ double VersionStorageInfo::GetEstimatedCompressionRatioAtLevel(
   uint64_t sum_data_size_bytes = 0;
   for (auto* file_meta : files_[level]) {
     auto raw_size = file_meta->raw_key_size + file_meta->raw_value_size;
+    // Otherwise it means the table properties is still initialized. Because in
+    // `UpdateAccumulatedStats` we limit the maximum number of properties to
+    // read once.
     if (raw_size > 0) {
       sum_file_size_bytes += file_meta->fd.GetFileSize();
       sum_data_size_bytes += raw_size;

--- a/db/version_set.cc
+++ b/db/version_set.cc
@@ -1570,8 +1570,11 @@ double VersionStorageInfo::GetEstimatedCompressionRatioAtLevel(
   uint64_t sum_file_size_bytes = 0;
   uint64_t sum_data_size_bytes = 0;
   for (auto* file_meta : files_[level]) {
-    sum_file_size_bytes += file_meta->fd.GetFileSize();
-    sum_data_size_bytes += file_meta->raw_key_size + file_meta->raw_value_size;
+    auto raw_size = file_meta->raw_key_size + file_meta->raw_value_size;
+    if (raw_size > 0) {
+      sum_file_size_bytes += file_meta->fd.GetFileSize();
+      sum_data_size_bytes += raw_size;
+    }
   }
   if (sum_file_size_bytes == 0) {
     return -1.0;


### PR DESCRIPTION
Raw key value size is stored in table properties. They may not be read out immediately after compaction. This is why after compaction (or restart) the compression ratio is always wrong.

This PR excludes those files without a meaningful table property.