### PR TITLE
use expected age instead of size to avoid spurious flush

### DIFF
--- a/db/db_write_buffer_manager_test.cc
+++ b/db/db_write_buffer_manager_test.cc
@@ -917,6 +917,87 @@ TEST_P(DBWriteBufferManagerTest, MixedSlowDownOptionsMultipleDB) {
   ROCKSDB_NAMESPACE::SyncPoint::GetInstance()->DisableProcessing();
 }
 
+// Test write can progress even if manual compaction and background work is
+// paused.
+TEST_P(DBWriteBufferManagerTest, BackgroundWorkPaused) {
+  std::vector<std::string> dbnames;
+  std::vector<DB*> dbs;
+  int num_dbs = 4;
+
+  for (int i = 0; i < num_dbs; i++) {
+    dbs.push_back(nullptr);
+    dbnames.push_back(
+        test::PerThreadDBPath("db_shared_wb_db" + std::to_string(i)));
+  }
+
+  Options options = CurrentOptions();
+  options.arena_block_size = 4096;
+  options.write_buffer_size = 500000;          // this is never hit
+  options.avoid_flush_during_shutdown = true;  // avoid blocking destroy forever
+  std::shared_ptr<Cache> cache = NewLRUCache(4 * 1024 * 1024, 2);
+  ASSERT_LT(cache->GetUsage(), 256 * 1024);
+  cost_cache_ = GetParam();
+
+  // Do not enable write stall.
+  if (cost_cache_) {
+    options.write_buffer_manager.reset(
+        new WriteBufferManager(100000, cache, 0.0));
+  } else {
+    options.write_buffer_manager.reset(
+        new WriteBufferManager(100000, nullptr, 0.0));
+  }
+  DestroyAndReopen(options);
+
+  for (int i = 0; i < num_dbs; i++) {
+    ASSERT_OK(DestroyDB(dbnames[i], options));
+    ASSERT_OK(DB::Open(options, dbnames[i], &(dbs[i])));
+  }
+
+  dbfull()->DisableManualCompaction();
+  ASSERT_OK(dbfull()->PauseBackgroundWork());
+  for (int i = 0; i < num_dbs; i++) {
+    dbs[i]->DisableManualCompaction();
+    ASSERT_OK(dbs[i]->PauseBackgroundWork());
+  }
+
+  WriteOptions wo;
+  wo.disableWAL = true;
+
+  // Make sure each db has something to flush.
+  ASSERT_OK(Put(Key(1), DummyString(1), wo));
+  for (int i = 0; i < num_dbs; i++) {
+    ASSERT_OK(dbs[i]->Put(wo, Key(1), DummyString(1)));
+  }
+  // Exceed the limit.
+  ASSERT_OK(Put(Key(2), DummyString(100000), wo));
+  // Write another one to trigger the flush.
+  ASSERT_OK(Put(Key(3), DummyString(1), wo));
+
+  bool found = false;
+  for (int i = 0; i < num_dbs; i++) {
+    ASSERT_OK(dbs[i]->ContinueBackgroundWork());
+    ASSERT_OK(
+        static_cast_with_check<DBImpl>(dbs[i])->TEST_WaitForFlushMemTable());
+    std::string property;
+    EXPECT_TRUE(dbs[i]->GetProperty("rocksdb.num-files-at-level0", &property));
+    int num = atoi(property.c_str());
+    if (!found) {
+      ASSERT_LE(num, 1);
+      found = (num == 1);
+    } else {
+      ASSERT_EQ(num, 0);
+    }
+  }
+  ASSERT_TRUE(found);
+
+  // Clean up DBs.
+  for (int i = 0; i < num_dbs; i++) {
+    ASSERT_OK(dbs[i]->Close());
+    ASSERT_OK(DestroyDB(dbnames[i], options));
+    delete dbs[i];
+  }
+}
+
 INSTANTIATE_TEST_CASE_P(DBWriteBufferManagerTest, DBWriteBufferManagerTest,
                         testing::Bool());
 

--- a/include/rocksdb/options.h
+++ b/include/rocksdb/options.h
@@ -1717,7 +1717,8 @@ struct FlushOptions {
   // Default: false
   bool allow_write_stall;
   // Only flush memtable if it has the expected oldest key time.
-  // Zero is no-op. Ignored for atomic flush.
+  // This option is ignored for atomic flush. Zero means disabling the check.
+  // Default: 0
   uint64_t expected_oldest_key_time;
   // Abort flush if compaction is disabled via `DisableManualCompaction`.
   // Default: false

--- a/include/rocksdb/options.h
+++ b/include/rocksdb/options.h
@@ -1719,6 +1719,9 @@ struct FlushOptions {
   // Only flush memtable if it has the expected oldest key time.
   // Zero is no-op. Ignored for atomic flush.
   uint64_t expected_oldest_key_time;
+  // Abort flush if compaction is disabled via `DisableManualCompaction`.
+  // Default: false
+  bool check_if_compaction_disabled;
   // Used by RocksDB internally.
   // Default: false
   bool _write_stopped;
@@ -1727,6 +1730,7 @@ struct FlushOptions {
       : wait(true),
         allow_write_stall(false),
         expected_oldest_key_time(0),
+        check_if_compaction_disabled(false),
         _write_stopped(false) {}
 };
 

--- a/include/rocksdb/options.h
+++ b/include/rocksdb/options.h
@@ -1716,10 +1716,9 @@ struct FlushOptions {
   // is performed by someone else (foreground call or background thread).
   // Default: false
   bool allow_write_stall;
-  // Only switch mutable memtable if its size is no smaller than this parameter.
-  // Zero is no-op.
-  // Default: 0
-  uint64_t min_size_to_flush;
+  // Only flush memtable if it has the expected oldest key time.
+  // Zero is no-op. Ignored for atomic flush.
+  uint64_t expected_oldest_key_time;
   // Used by RocksDB internally.
   // Default: false
   bool _write_stopped;
@@ -1727,7 +1726,7 @@ struct FlushOptions {
   FlushOptions()
       : wait(true),
         allow_write_stall(false),
-        min_size_to_flush(0),
+        expected_oldest_key_time(0),
         _write_stopped(false) {}
 };
 

--- a/memtable/write_buffer_manager.cc
+++ b/memtable/write_buffer_manager.cc
@@ -219,10 +219,11 @@ void WriteBufferManager::MaybeFlushLocked(DB* this_db) {
         current_score = current_score * (100 - factor) / factor;
       }
     }
-    if (current_score > std::get<1>(candidates[0])) {
-      candidates[0] = {s.get(), current_score, oldest_time};
-    } else if (current_score > std::get<1>(candidates[1])) {
-      candidates[1] = {s.get(), current_score, oldest_time};
+    for (size_t i = 0; i < kCandidateSize; i++) {
+      if (current_score > std::get<1>(candidates[i])) {
+        candidates[i] = {s.get(), current_score, oldest_time};
+        break;
+      }
     }
   }
 
@@ -237,7 +238,6 @@ void WriteBufferManager::MaybeFlushLocked(DB* this_db) {
       if (i < kCandidateSize - 1) {
         // Don't check it for the last candidate. Otherwise we could end up
         // never progressing.
-        // TODO: add a test case.
         flush_opts.check_if_compaction_disabled = true;
       }
       auto s = candidate->db->Flush(flush_opts, candidate->cf);

--- a/memtable/write_buffer_manager.cc
+++ b/memtable/write_buffer_manager.cc
@@ -178,13 +178,15 @@ void WriteBufferManager::MaybeFlushLocked(DB* this_db) {
   if (!ShouldFlush()) {
     return;
   }
+  // Have at least one candidate to flush with
+  // check_if_compaction_disabled=false when all others failed.
   constexpr size_t kCandidateSize = 2;
-  // We only flush at most one column family at a time.
-  // This is enough to keep size under control except when flush_size is
-  // dynamically decreased. That case is managed in `SetFlushSize`.
   // (score, age).
-  std::tuple<WriteBufferSentinel*, uint64_t, uint64_t>
-      candidates[kCandidateSize];
+  using Candidate = std::tuple<WriteBufferSentinel*, uint64_t, uint64_t>;
+  auto cmp = [](const Candidate& a, const Candidate& b) {
+    return std::get<1>(a) <= std::get<1>(b);
+  };
+  std::set<Candidate, decltype(cmp)> candidates(cmp);
 
   for (auto& s : sentinels_) {
     // TODO: move this calculation to a callback.
@@ -219,37 +221,37 @@ void WriteBufferManager::MaybeFlushLocked(DB* this_db) {
         current_score = current_score * (100 - factor) / factor;
       }
     }
-    for (size_t i = 0; i < kCandidateSize; i++) {
-      if (current_score > std::get<1>(candidates[i])) {
-        candidates[i] = {s.get(), current_score, oldest_time};
-        break;
-      }
+    candidates.insert({s.get(), current_score, oldest_time});
+    if (candidates.size() > kCandidateSize) {
+      candidates.erase(candidates.begin());
     }
   }
 
-  for (size_t i = 0; i < kCandidateSize; i++) {
-    auto candidate = std::get<0>(candidates[i]);
-    if (candidate != nullptr) {
-      FlushOptions flush_opts;
-      flush_opts.allow_write_stall = true;
-      flush_opts.wait = false;
-      flush_opts._write_stopped = (candidate->db == this_db);
-      flush_opts.expected_oldest_key_time = std::get<2>(candidates[i]);
-      if (i < kCandidateSize - 1) {
-        // Don't check it for the last candidate. Otherwise we could end up
-        // never progressing.
-        flush_opts.check_if_compaction_disabled = true;
-      }
-      auto s = candidate->db->Flush(flush_opts, candidate->cf);
-      if (!s.ok()) {
-        auto opts = candidate->db->GetDBOptions();
-        ROCKS_LOG_INFO(opts.info_log, "WriteBufferManager fails to flush: %s",
-                       s.ToString().c_str());
-        // Fallback to the next best candidate.
-        continue;
-      }
+  // We only flush at most one column family at a time.
+  // This is enough to keep size under control except when flush_size is
+  // dynamically decreased. That case is managed in `SetFlushSize`.
+  auto candidate = candidates.rbegin();
+  while (candidate != candidates.rend()) {
+    auto sentinel = std::get<0>(*candidate);
+    FlushOptions flush_opts;
+    flush_opts.allow_write_stall = true;
+    flush_opts.wait = false;
+    flush_opts._write_stopped = (sentinel->db == this_db);
+    flush_opts.expected_oldest_key_time = std::get<2>(*candidate);
+    candidate++;
+    if (candidate != candidates.rend()) {
+      // Don't check it for the last candidate. Otherwise we could end up
+      // never progressing.
+      flush_opts.check_if_compaction_disabled = true;
     }
-    break;
+    auto s = sentinel->db->Flush(flush_opts, sentinel->cf);
+    if (s.ok()) {
+      return;
+    }
+    auto opts = sentinel->db->GetDBOptions();
+    ROCKS_LOG_WARN(opts.info_log, "WriteBufferManager fails to flush: %s",
+                   s.ToString().c_str());
+    // Fallback to the next best candidate.
   }
 }
 


### PR DESCRIPTION
Also added a new options to detect whether manual compaction is disabled. In practice we use this to avoid blocking on flushing a tablet that will be destroyed shortly after.