### PR TITLE
compaction: send file size and range segments to compaction partitioner context

### DIFF
--- a/db/compaction/compaction.cc
+++ b/db/compaction/compaction.cc
@@ -597,15 +597,15 @@ Compaction::CreateSegmentsForLevel(int in_level) const {
     // There is no overlapping of next level.
     return std::make_pair(std::vector<Slice>(), std::vector<uint64_t>());
   }
-
   std::vector<Slice> ranges;
   std::vector<uint64_t> sizes;
-  ranges.push_back(start->smallest_key);
+  // The LevelFileBrief holds raw key...
+  ranges.push_back(ExtractUserKey(start->smallest_key));
   for (const FdWithKeyRange* iter = start; iter < end; iter++) {
-    if (cmp->Compare(iter->smallest_key, largest_user_key_) > 0) {
+    if (cmp->Compare(ExtractUserKey(iter->smallest_key), largest_user_key_) > 0) {
       break;
     }
-    ranges.push_back(iter->largest_key);
+    ranges.push_back(ExtractUserKey(iter->largest_key));
     sizes.push_back(iter->fd.GetFileSize());
   }
   return std::make_pair(ranges, sizes);

--- a/db/compaction/compaction.cc
+++ b/db/compaction/compaction.cc
@@ -593,8 +593,7 @@ std::vector<SstPartitioner::Segment> Compaction::CreateSegmentsForLevel(
       });
   const auto end = files.files + files.num_files;
 
-  if (bgn == end) 
-  {
+  if (bgn == end) {
     return std::vector<SstPartitioner::Segment>();
   }
 
@@ -620,7 +619,8 @@ std::unique_ptr<SstPartitioner> Compaction::CreateSstPartitioner() const {
   context.output_level = output_level_;
   context.smallest_user_key = smallest_user_key_;
   context.largest_user_key = largest_user_key_;
-  context.output_next_level_segments = CreateSegmentsForLevel(output_level_ + 1);
+  context.output_next_level_segments =
+      CreateSegmentsForLevel(output_level_ + 1);
   return immutable_options_.sst_partitioner_factory->CreatePartitioner(context);
 }
 

--- a/db/compaction/compaction.cc
+++ b/db/compaction/compaction.cc
@@ -585,7 +585,8 @@ Compaction::CreateSegmentsForLevel(int in_level) const {
     return std::make_pair(std::vector<Slice>(), std::vector<uint64_t>());
   }
   const auto& files = vsi->LevelFilesBrief(in_level);
-  // The file metadata hold internal keys, however the compaction is bounded by user keys.
+  // The file metadata hold internal keys, however the compaction is bounded by
+  // user keys.
   const auto user_cmp = immutable_options()->user_comparator;
   const auto start = std::lower_bound(
       files.files, files.files + files.num_files, smallest_user_key_,
@@ -602,7 +603,8 @@ Compaction::CreateSegmentsForLevel(int in_level) const {
   std::vector<uint64_t> sizes;
   ranges.push_back(ExtractUserKey(start->smallest_key));
   for (const FdWithKeyRange* iter = start; iter < end; iter++) {
-    if (user_cmp->Compare(ExtractUserKey(iter->smallest_key), largest_user_key_) > 0) {
+    if (user_cmp->Compare(ExtractUserKey(iter->smallest_key),
+                          largest_user_key_) > 0) {
       break;
     }
     ranges.push_back(ExtractUserKey(iter->largest_key));

--- a/db/compaction/compaction.cc
+++ b/db/compaction/compaction.cc
@@ -590,7 +590,7 @@ Compaction::CreateSegmentsForLevel(int in_level) const {
   const auto user_cmp = immutable_options()->user_comparator;
   const auto end = files.files + files.num_files;
   const auto start = std::lower_bound(
-      files.files, files.files + files.num_files, smallest_user_key_,
+      files.files, end, smallest_user_key_,
       [user_cmp](FdWithKeyRange& fd, const Slice& slice) {
         return user_cmp->Compare(ExtractUserKey(fd.largest_key), slice) < 0;
       });

--- a/db/compaction/compaction.cc
+++ b/db/compaction/compaction.cc
@@ -593,7 +593,8 @@ std::vector<SstPartitioner::Segment> Compaction::CreateSegmentsForLevel(
       });
   const auto end = files.files + files.num_files;
 
-  if (bgn == end) {
+  if (bgn == end) 
+  {
     return std::vector<SstPartitioner::Segment>();
   }
 
@@ -619,8 +620,7 @@ std::unique_ptr<SstPartitioner> Compaction::CreateSstPartitioner() const {
   context.output_level = output_level_;
   context.smallest_user_key = smallest_user_key_;
   context.largest_user_key = largest_user_key_;
-  context.output_next_level_segments =
-      CreateSegmentsForLevel(output_level_ + 1);
+  context.output_next_level_segments = CreateSegmentsForLevel(output_level_ + 1);
   return immutable_options_.sst_partitioner_factory->CreatePartitioner(context);
 }
 

--- a/db/compaction/compaction.cc
+++ b/db/compaction/compaction.cc
@@ -10,6 +10,7 @@
 #include "db/compaction/compaction.h"
 
 #include <cinttypes>
+#include <algorithm>
 #include <vector>
 
 #include "db/column_family.h"
@@ -564,6 +565,18 @@ std::unique_ptr<CompactionFilter> Compaction::CreateCompactionFilter(
   context.reason = TableFileCreationReason::kCompaction;
   return cfd_->ioptions()->compaction_filter_factory->CreateCompactionFilter(
       context);
+}
+
+std::vector<SstPartitioner::Segment> CreateSegmentsForLevel(
+  const Version* version,
+  Slice smallest_user_key,
+  Slice largest_user_key,
+  int in_level) {
+    const auto files = version->storage_info()->LevelFilesBrief(in_level);
+    std::vector<SstPartitioner::Segment> segs;
+    for (int i = 0; i < files.num_files; i ++) {
+      const auto& file = files.files[i];
+    }
 }
 
 std::unique_ptr<SstPartitioner> Compaction::CreateSstPartitioner() const {

--- a/db/compaction/compaction.cc
+++ b/db/compaction/compaction.cc
@@ -622,7 +622,8 @@ std::unique_ptr<SstPartitioner> Compaction::CreateSstPartitioner() const {
   context.output_level = output_level_;
   context.smallest_user_key = smallest_user_key_;
   context.largest_user_key = largest_user_key_;
-  std::tie(context.output_next_level_boundaries, context.output_next_level_size) =
+  std::tie(context.output_next_level_boundaries,
+           context.output_next_level_size) =
       CreateSegmentsForLevel(output_level_ + 1);
   return immutable_options_.sst_partitioner_factory->CreatePartitioner(context);
 }

--- a/db/compaction/compaction.cc
+++ b/db/compaction/compaction.cc
@@ -568,11 +568,11 @@ std::unique_ptr<CompactionFilter> Compaction::CreateCompactionFilter(
 }
 
 std::pair<std::vector<Slice>, std::vector<uint64_t>>
-Compaction::CreateSegmentsForLevel(int in_level) const {
+Compaction::CreateSegmentsForLevel(int level) const {
   // So... the below files should be adjacently sorted.
   // For now, this is only for creating the next-of-output level info, so it
   // makes sense for not supporting L0.
-  assert(in_level != 0);
+  assert(level != 0);
 
   // Some of test cases may not initialize the version...
   if (input_version_ == nullptr) {
@@ -580,11 +580,11 @@ Compaction::CreateSegmentsForLevel(int in_level) const {
   }
 
   const auto vsi = input_version_->storage_info();
-  if (in_level >= vsi->num_non_empty_levels()) {
+  if (level >= vsi->num_non_empty_levels()) {
     // The level shall be empty.
     return std::make_pair(std::vector<Slice>(), std::vector<uint64_t>());
   }
-  const auto& files = vsi->LevelFilesBrief(in_level);
+  const auto& files = vsi->LevelFilesBrief(level);
   // The file metadata hold internal keys, however the compaction is bounded by
   // user keys.
   const auto user_cmp = immutable_options()->user_comparator;

--- a/db/compaction/compaction.cc
+++ b/db/compaction/compaction.cc
@@ -588,12 +588,12 @@ Compaction::CreateSegmentsForLevel(int in_level) const {
   // The file metadata hold internal keys, however the compaction is bounded by
   // user keys.
   const auto user_cmp = immutable_options()->user_comparator;
+  const auto end = files.files + files.num_files;
   const auto start = std::lower_bound(
       files.files, files.files + files.num_files, smallest_user_key_,
       [user_cmp](FdWithKeyRange& fd, const Slice& slice) {
         return user_cmp->Compare(ExtractUserKey(fd.largest_key), slice) < 0;
       });
-  const auto end = files.files + files.num_files;
 
   if (start == end) {
     // There is no overlapping of next level.
@@ -610,7 +610,6 @@ Compaction::CreateSegmentsForLevel(int in_level) const {
     ranges.push_back(ExtractUserKey(iter->largest_key));
     sizes.push_back(iter->fd.GetFileSize());
   }
-  InternalKey("A", 0, ValueType::kTypeDeletion);
   return std::make_pair(ranges, sizes);
 }
 

--- a/db/compaction/compaction.cc
+++ b/db/compaction/compaction.cc
@@ -574,6 +574,11 @@ std::vector<SstPartitioner::Segment> Compaction::CreateSegmentsForLevel(
   // makes sense for not supporting L0.
   assert(in_level != 0);
 
+  // Some of test cases may not initialize the version...
+  if (input_version_ == nullptr) {
+    return std::vector<SstPartitioner::Segment>();
+  }
+
   const auto vsi = input_version_->storage_info();
   if (in_level >= vsi->num_non_empty_levels()) {
     // The level shall be empty.

--- a/db/compaction/compaction.h
+++ b/db/compaction/compaction.h
@@ -345,6 +345,7 @@ class Compaction {
 
   static bool IsFullCompaction(VersionStorageInfo* vstorage,
                                const std::vector<CompactionInputFiles>& inputs);
+  std::vector<SstPartitioner::Segment> CreateSegmentsForLevel(int level) const;
 
   VersionStorageInfo* input_vstorage_;
 

--- a/db/compaction/compaction.h
+++ b/db/compaction/compaction.h
@@ -345,7 +345,9 @@ class Compaction {
 
   static bool IsFullCompaction(VersionStorageInfo* vstorage,
                                const std::vector<CompactionInputFiles>& inputs);
-  std::vector<SstPartitioner::Segment> CreateSegmentsForLevel(int level) const;
+
+  std::pair<std::vector<Slice>, std::vector<uint64_t>> CreateSegmentsForLevel(
+      int in_level) const;
 
   VersionStorageInfo* input_vstorage_;
 

--- a/db/db_compaction_test.cc
+++ b/db/db_compaction_test.cc
@@ -1065,7 +1065,7 @@ TEST_F(DBCompactionTest, CompactionSstPartitionerNextLevel) {
   options.max_bytes_for_level_multiplier = 2;
   options.sst_partitioner_factory = std::unique_ptr<SstPartitionerFactory>(
       new SplitAllPatitionerFactory([this](const SstPartitioner::Context& cx) {
-        if (!cx.output_next_level_segments.empty()) {
+        if (!cx.output_next_level_boundaries.empty()) {
           std::vector<LiveFileMetaData> files;
           // We are holding the mutex in this context...
           // Perhaps we'd better make a `TEST_GetVersion` for fetching.
@@ -1080,10 +1080,9 @@ TEST_F(DBCompactionTest, CompactionSstPartitionerNextLevel) {
                        Slice(ld.largestkey).compare(cx.smallest_user_key) > 0 &&
                        ld.level == cx.output_level + 1;
               });
-          if (!cx.output_next_level_segments.empty()) {
-            ASSERT_EQ(next_level_overlap_files + 1,
-                      cx.output_next_level_segments.size());
-          }
+          ASSERT_EQ(next_level_overlap_files + 1,
+                    cx.output_next_level_boundaries.size());
+          ASSERT_EQ(next_level_overlap_files, cx.output_next_level_size.size());
         }
       }));
   DestroyAndReopen(options);

--- a/db/db_compaction_test.cc
+++ b/db/db_compaction_test.cc
@@ -1116,10 +1116,15 @@ TEST_F(DBCompactionTest, CompactionSstPartitionerNextLevel) {
   ASSERT_OK(Flush());
   ASSERT_OK(dbfull()->TEST_WaitForFlushMemTable());
   ASSERT_OK(dbfull()->TEST_WaitForCompact(true));
+  ASSERT_OK(Put(InternalKey("A", 0, ValueType::kTypeDeletion).Encode(), "And a tricker: he pretends to be A, but not A."));
+  ASSERT_OK(Put(InternalKey("B", 0, ValueType::kTypeDeletion).Encode(), "Yeah, another tricker."));
+  ASSERT_OK(Flush());
+  ASSERT_OK(dbfull()->TEST_WaitForFlushMemTable());
+  ASSERT_OK(dbfull()->TEST_WaitForCompact(true));
 
   std::vector<LiveFileMetaData> files;
   dbfull()->GetLiveFilesMetaData(&files);
-  ASSERT_EQ(6, files.size());
+  ASSERT_EQ(8, files.size());
 }
 
 TEST_F(DBCompactionTest, ZeroSeqIdCompaction) {

--- a/db/db_compaction_test.cc
+++ b/db/db_compaction_test.cc
@@ -99,9 +99,8 @@ class SplitAllPatitionerFactory : public SstPartitionerFactory {
  public:
   std::function<void(const SstPartitioner::Context&)> on_create_;
 
-  SplitAllPatitionerFactory(
-      std::function<void(const SstPartitioner::Context&)> on_create)
-      : on_create_(on_create) {}
+  SplitAllPatitionerFactory(std::function<void(const SstPartitioner::Context&)> on_create) :
+    on_create_(on_create) {}
 
   std::unique_ptr<SstPartitioner> CreatePartitioner(
       const SstPartitioner::Context& context) const override {
@@ -139,10 +138,9 @@ class FlushedFileCollector : public EventListener {
 };
 
 class CompactionStatsCollector : public EventListener {
- public:
+public:
   CompactionStatsCollector()
-      : compaction_completed_(
-            static_cast<int>(CompactionReason::kNumOfReasons)) {
+      : compaction_completed_(static_cast<int>(CompactionReason::kNumOfReasons)) {
     for (auto& v : compaction_completed_) {
       v.store(0);
     }
@@ -176,7 +174,7 @@ class CompactionStatsCollector : public EventListener {
     return compaction_completed_.at(k).load();
   }
 
- private:
+private:
   std::vector<std::atomic<int>> compaction_completed_;
 };
 
@@ -215,8 +213,9 @@ Options DeletionTriggerOptions(Options options) {
   return options;
 }
 
-bool HaveOverlappingKeyRanges(const Comparator* c, const SstFileMetaData& a,
-                              const SstFileMetaData& b) {
+bool HaveOverlappingKeyRanges(
+    const Comparator* c,
+    const SstFileMetaData& a, const SstFileMetaData& b) {
   if (c->CompareWithoutTimestamp(a.smallestkey, b.smallestkey) >= 0) {
     if (c->CompareWithoutTimestamp(a.smallestkey, b.largestkey) <= 0) {
       // b.smallestkey <= a.smallestkey <= b.largestkey
@@ -241,15 +240,18 @@ bool HaveOverlappingKeyRanges(const Comparator* c, const SstFileMetaData& a,
 // Identifies all files between level "min_level" and "max_level"
 // which has overlapping key range with "input_file_meta".
 void GetOverlappingFileNumbersForLevelCompaction(
-    const ColumnFamilyMetaData& cf_meta, const Comparator* comparator,
-    int min_level, int max_level, const SstFileMetaData* input_file_meta,
+    const ColumnFamilyMetaData& cf_meta,
+    const Comparator* comparator,
+    int min_level, int max_level,
+    const SstFileMetaData* input_file_meta,
     std::set<std::string>* overlapping_file_names) {
   std::set<const SstFileMetaData*> overlapping_files;
   overlapping_files.insert(input_file_meta);
   for (int m = min_level; m <= max_level; ++m) {
     for (auto& file : cf_meta.levels[m].files) {
       for (auto* included_file : overlapping_files) {
-        if (HaveOverlappingKeyRanges(comparator, *included_file, file)) {
+        if (HaveOverlappingKeyRanges(
+                comparator, *included_file, file)) {
           overlapping_files.insert(&file);
           overlapping_file_names->insert(file.name);
           break;
@@ -280,7 +282,7 @@ void VerifyCompactionResult(
  * 2) stat.counts[i] == collector.NumberOfCompactions(i)
  */
 void VerifyCompactionStats(ColumnFamilyData& cfd,
-                           const CompactionStatsCollector& collector) {
+    const CompactionStatsCollector& collector) {
 #ifndef NDEBUG
   InternalStats* internal_stats_ptr = cfd.internal_stats();
   ASSERT_NE(internal_stats_ptr, nullptr);
@@ -301,15 +303,17 @@ void VerifyCompactionStats(ColumnFamilyData& cfd,
   // Verify InternalStats bookkeeping matches that of CompactionStatsCollector,
   // assuming that all compactions complete.
   for (int i = 0; i < num_of_reasons; i++) {
-    ASSERT_EQ(collector.NumberOfCompactions(static_cast<CompactionReason>(i)),
-              counts[i]);
+    ASSERT_EQ(collector.NumberOfCompactions(static_cast<CompactionReason>(i)), counts[i]);
   }
 #endif /* NDEBUG */
 }
 
-const SstFileMetaData* PickFileRandomly(const ColumnFamilyMetaData& cf_meta,
-                                        Random* rand, int* level = nullptr) {
-  auto file_id = rand->Uniform(static_cast<int>(cf_meta.file_count)) + 1;
+const SstFileMetaData* PickFileRandomly(
+    const ColumnFamilyMetaData& cf_meta,
+    Random* rand,
+    int* level = nullptr) {
+  auto file_id = rand->Uniform(static_cast<int>(
+      cf_meta.file_count)) + 1;
   for (auto& level_meta : cf_meta.levels) {
     if (file_id <= level_meta.files.size()) {
       if (level != nullptr) {
@@ -736,6 +740,7 @@ TEST_F(DBCompactionTest, DisableStatsUpdateReopen) {
   }
 }
 
+
 TEST_P(DBCompactionTestWithParam, CompactionTrigger) {
   const int kNumKeysPerFile = 100;
 
@@ -878,7 +883,7 @@ TEST_F(DBCompactionTest, BGCompactionsAllowed) {
 
 TEST_P(DBCompactionTestWithParam, CompactionsGenerateMultipleFiles) {
   Options options = CurrentOptions();
-  options.write_buffer_size = 100000000;  // Large write buffer
+  options.write_buffer_size = 100000000;        // Large write buffer
   options.max_subcompactions = max_subcompactions_;
   CreateAndReopenWithCF({"pikachu"}, options);
 
@@ -1057,29 +1062,23 @@ TEST_F(DBCompactionTest, CompactionSstPartitionerNextLevel) {
   options.level0_file_num_compaction_trigger = 1;
   options.max_bytes_for_level_base = 10;
   options.max_bytes_for_level_multiplier = 2;
-  options.sst_partitioner_factory = std::unique_ptr<SstPartitionerFactory>(
-      new SplitAllPatitionerFactory([this](const SstPartitioner::Context& cx) {
-        if (!cx.output_next_level_segments.empty()) {
-          std::vector<LiveFileMetaData> files;
-          // We are holding the mutex in this context...
-          // Perhaps we'd better make a `TEST_GetVersion` for fetching.
-          dbfull()->TEST_UnlockMutex();
-          dbfull()->GetLiveFilesMetaData(&files);
-          dbfull()->TEST_LockMutex();
-          auto next_level_overlap_files = std::count_if(
-              files.begin(), files.end(), [&](const LiveFileMetaData& ld) {
-                // Check whether the file is in range [cx.smallest_user_key,
-                // cx.largest_user_key) and in the level cx.output_level + 1.
-                return Slice(ld.smallestkey).compare(cx.largest_user_key) < 0 &&
-                       Slice(ld.largestkey).compare(cx.smallest_user_key) > 0 &&
-                       ld.level == cx.output_level + 1;
-              });
-          if (!cx.output_next_level_segments.empty()) {
-            ASSERT_EQ(next_level_overlap_files + 1,
-                      cx.output_next_level_segments.size());
-          }
-        }
-      }));
+  options.sst_partitioner_factory = std::unique_ptr<SstPartitionerFactory>(new SplitAllPatitionerFactory([this](const SstPartitioner::Context& cx) {
+    if (!cx.output_next_level_segments.empty()) {
+      std::vector<LiveFileMetaData> files;
+      // We are holding the mutex in this context...
+      // Perhaps we'd better make a `TEST_GetVersion` for fetching.
+      dbfull()->TEST_UnlockMutex();
+      dbfull()->GetLiveFilesMetaData(&files);
+      dbfull()->TEST_LockMutex();
+      auto next_level_overlap_files = std::count_if(files.begin(), files.end(), [&](const LiveFileMetaData& ld){
+        // Check whether the file is in range [cx.smallest_user_key, cx.largest_user_key) and in the level cx.output_level + 1.
+        return Slice(ld.smallestkey).compare(cx.largest_user_key) < 0 && Slice(ld.largestkey).compare(cx.smallest_user_key) > 0 && ld.level == cx.output_level + 1;
+      });
+      if (!cx.output_next_level_segments.empty()) {
+        ASSERT_EQ(next_level_overlap_files + 1, cx.output_next_level_segments.size());
+      }
+    }
+  }));
   DestroyAndReopen(options);
 
   ASSERT_OK(Put("A", "there are more than 10 bytes."));
@@ -1096,7 +1095,7 @@ TEST_F(DBCompactionTest, CompactionSstPartitionerNextLevel) {
   ASSERT_OK(Flush());
   ASSERT_OK(dbfull()->TEST_WaitForFlushMemTable());
   ASSERT_OK(dbfull()->TEST_WaitForCompact(true));
-
+    
   std::vector<LiveFileMetaData> files;
   dbfull()->GetLiveFilesMetaData(&files);
   ASSERT_EQ(6, files.size());
@@ -1115,7 +1114,7 @@ TEST_F(DBCompactionTest, ZeroSeqIdCompaction) {
   compact_opt.compression = kNoCompression;
   compact_opt.output_file_size_limit = 4096;
   const size_t key_len =
-      static_cast<size_t>(compact_opt.output_file_size_limit) / 5;
+    static_cast<size_t>(compact_opt.output_file_size_limit) / 5;
 
   DestroyAndReopen(options);
 
@@ -1289,8 +1288,14 @@ TEST_P(DBCompactionTestWithParam, TrivialMoveNonOverlappingFiles) {
   DestroyAndReopen(options);
   // non overlapping ranges
   std::vector<std::pair<int32_t, int32_t>> ranges = {
-      {100, 199}, {300, 399}, {0, 99},    {200, 299},
-      {600, 699}, {400, 499}, {500, 550}, {551, 599},
+    {100, 199},
+    {300, 399},
+    {0, 99},
+    {200, 299},
+    {600, 699},
+    {400, 499},
+    {500, 550},
+    {551, 599},
   };
   int32_t value_size = 10 * 1024;  // 10 KB
 
@@ -1333,10 +1338,14 @@ TEST_P(DBCompactionTestWithParam, TrivialMoveNonOverlappingFiles) {
   DestroyAndReopen(options);
   // Same ranges as above but overlapping
   ranges = {
-      {100, 199}, {300, 399}, {0, 99},    {200, 299},
-      {600, 699}, {400, 499}, {500, 560},  // this range overlap with the next
-                                           // one
-      {551, 599},
+    {100, 199},
+    {300, 399},
+    {0, 99},
+    {200, 299},
+    {600, 699},
+    {400, 499},
+    {500, 560},  // this range overlap with the next one
+    {551, 599},
   };
   for (size_t i = 0; i < ranges.size(); i++) {
     for (int32_t j = ranges[i].first; j <= ranges[i].second; j++) {
@@ -1871,7 +1880,7 @@ TEST_F(DBCompactionTest, DeleteFilesInRanges) {
   ASSERT_EQ("0,0,10", FilesPerLevel(0));
 
   // file [0 => 100), [200 => 300), ... [800, 900)
-  for (auto i = 0; i < 10; i += 2) {
+  for (auto i = 0; i < 10; i+=2) {
     for (auto j = 0; j < 100; j++) {
       auto k = i * 100 + j;
       ASSERT_OK(Put(Key(k), values[k]));
@@ -2313,14 +2322,14 @@ TEST_P(DBCompactionTestWithParam, LevelCompactionCFPathUse) {
   cf_opt1.cf_paths.emplace_back(dbname_ + "cf1_2", 4 * 1024 * 1024);
   cf_opt1.cf_paths.emplace_back(dbname_ + "cf1_3", 1024 * 1024 * 1024);
   option_vector.emplace_back(DBOptions(options), cf_opt1);
-  CreateColumnFamilies({"one"}, option_vector[1]);
+  CreateColumnFamilies({"one"},option_vector[1]);
 
   // Configure CF2 specific paths.
   cf_opt2.cf_paths.emplace_back(dbname_ + "cf2", 500 * 1024);
   cf_opt2.cf_paths.emplace_back(dbname_ + "cf2_2", 4 * 1024 * 1024);
   cf_opt2.cf_paths.emplace_back(dbname_ + "cf2_3", 1024 * 1024 * 1024);
   option_vector.emplace_back(DBOptions(options), cf_opt2);
-  CreateColumnFamilies({"two"}, option_vector[2]);
+  CreateColumnFamilies({"two"},option_vector[2]);
 
   ReopenWithColumnFamilies({"default", "one", "two"}, option_vector);
 
@@ -2668,6 +2677,7 @@ TEST_P(DBCompactionTestWithParam, ManualCompaction) {
   }
 }
 
+
 TEST_P(DBCompactionTestWithParam, ManualLevelCompactionOutputPathId) {
   Options options = CurrentOptions();
   options.db_paths.emplace_back(dbname_ + "_2", 2 * 10485760);
@@ -2804,13 +2814,14 @@ TEST_P(DBCompactionTestWithParam, DISABLED_CompactFilesOnLevelCompaction) {
       auto file_meta = PickFileRandomly(cf_meta, &rnd, &level);
       compaction_input_file_names.push_back(file_meta->name);
       GetOverlappingFileNumbersForLevelCompaction(
-          cf_meta, options.comparator, level, output_level, file_meta,
-          &overlapping_file_names);
+          cf_meta, options.comparator, level, output_level,
+          file_meta, &overlapping_file_names);
     }
 
-    ASSERT_OK(dbfull()->CompactFiles(CompactionOptions(), handles_[1],
-                                     compaction_input_file_names,
-                                     output_level));
+    ASSERT_OK(dbfull()->CompactFiles(
+        CompactionOptions(), handles_[1],
+        compaction_input_file_names,
+        output_level));
 
     // Make sure all overlapping files do not exist after compaction
     dbfull()->GetColumnFamilyMetaData(handles_[1], &cf_meta);
@@ -2833,7 +2844,8 @@ TEST_P(DBCompactionTestWithParam, PartialCompactionFailure) {
   options.write_buffer_size = kKeysPerBuffer * kKvSize;
   options.max_write_buffer_number = 2;
   options.target_file_size_base =
-      options.write_buffer_size * (options.max_write_buffer_number - 1);
+      options.write_buffer_size *
+      (options.max_write_buffer_number - 1);
   options.level0_file_num_compaction_trigger = kNumL1Files;
   options.max_bytes_for_level_base =
       options.level0_file_num_compaction_trigger *
@@ -2853,9 +2865,10 @@ TEST_P(DBCompactionTestWithParam, PartialCompactionFailure) {
 
   DestroyAndReopen(options);
 
-  const int kNumInsertedKeys = options.level0_file_num_compaction_trigger *
-                               (options.max_write_buffer_number - 1) *
-                               kKeysPerBuffer;
+  const int kNumInsertedKeys =
+      options.level0_file_num_compaction_trigger *
+      (options.max_write_buffer_number - 1) *
+      kKeysPerBuffer;
 
   Random rnd(301);
   std::vector<std::string> keys;
@@ -3553,8 +3566,9 @@ TEST_F(DBCompactionTest, CompactFilesPendingL0Bug) {
   ASSERT_EQ(kNumL0Files, cf_meta.levels[0].files.size());
   std::vector<std::string> input_filenames;
   input_filenames.push_back(cf_meta.levels[0].files.front().name);
-  ASSERT_OK(dbfull()->CompactFiles(CompactionOptions(), input_filenames,
-                                   0 /* output_level */));
+  ASSERT_OK(dbfull()
+                  ->CompactFiles(CompactionOptions(), input_filenames,
+                                 0 /* output_level */));
   TEST_SYNC_POINT("DBCompactionTest::CompactFilesPendingL0Bug:ManualCompacted");
   ROCKSDB_NAMESPACE::SyncPoint::GetInstance()->DisableProcessing();
 }
@@ -4201,9 +4215,9 @@ TEST_F(DBCompactionTest, LevelPeriodicAndTtlCompaction) {
   const int kValueSize = 100;
 
   Options options = CurrentOptions();
-  options.ttl = 10 * 60 * 60;                          // 10 hours
+  options.ttl = 10 * 60 * 60;  // 10 hours
   options.periodic_compaction_seconds = 48 * 60 * 60;  // 2 days
-  options.max_open_files = -1;  // needed for both periodic and ttl compactions
+  options.max_open_files = -1;   // needed for both periodic and ttl compactions
   env_->SetMockSleep();
   options.env = env_;
 
@@ -4618,7 +4632,7 @@ TEST_F(DBCompactionTest, CompactRangeSkipFlushAfterDelay) {
        {"DBImpl::FlushMemTable:StallWaitDone", "CompactionJob::Run():End"}});
   ROCKSDB_NAMESPACE::SyncPoint::GetInstance()->EnableProcessing();
 
-  // used for the delayable flushes
+  //used for the delayable flushes
   FlushOptions flush_opts;
   flush_opts.allow_write_stall = true;
   for (int i = 0; i < kNumL0FilesLimit - 1; ++i) {
@@ -4637,8 +4651,7 @@ TEST_F(DBCompactionTest, CompactRangeSkipFlushAfterDelay) {
   ASSERT_OK(Put(ToString(0), rnd.RandomString(1024)));
   ASSERT_OK(dbfull()->Flush(flush_opts));
   ASSERT_OK(Put(ToString(0), rnd.RandomString(1024)));
-  TEST_SYNC_POINT(
-      "DBCompactionTest::CompactRangeSkipFlushAfterDelay:PostFlush");
+  TEST_SYNC_POINT("DBCompactionTest::CompactRangeSkipFlushAfterDelay:PostFlush");
   manual_compaction_thread.join();
 
   // If CompactRange's flush was skipped, the final Put above will still be
@@ -4839,10 +4852,10 @@ TEST_F(DBCompactionTest, CompactionLimiter) {
   }
 
   std::shared_ptr<ConcurrentTaskLimiter> unique_limiter(
-      NewConcurrentTaskLimiter("unique_limiter", -1));
+    NewConcurrentTaskLimiter("unique_limiter", -1));
 
-  const char* cf_names[] = {"default", "0", "1", "2", "3", "4", "5", "6", "7",
-                            "8",       "9", "a", "b", "c", "d", "e", "f"};
+  const char* cf_names[] = {"default", "0", "1", "2", "3", "4", "5",
+    "6", "7", "8", "9", "a", "b", "c", "d", "e", "f" };
   const unsigned int cf_count = sizeof cf_names / sizeof cf_names[0];
 
   std::unordered_map<std::string, CompactionLimiter*> cf_to_limiter;
@@ -4854,10 +4867,10 @@ TEST_F(DBCompactionTest, CompactionLimiter) {
   options.level0_file_num_compaction_trigger = 4;
   options.level0_slowdown_writes_trigger = 64;
   options.level0_stop_writes_trigger = 64;
-  options.max_background_jobs = kMaxBackgroundThreads;  // Enough threads
+  options.max_background_jobs = kMaxBackgroundThreads; // Enough threads
   options.memtable_factory.reset(
       test::NewSpecialSkipListFactory(kNumKeysPerFile));
-  options.max_write_buffer_number = 10;  // Enough memtables
+  options.max_write_buffer_number = 10; // Enough memtables
   DestroyAndReopen(options);
 
   std::vector<Options> option_vector;
@@ -4885,8 +4898,9 @@ TEST_F(DBCompactionTest, CompactionLimiter) {
     CreateColumnFamilies({cf_names[cf]}, option_vector[cf]);
   }
 
-  ReopenWithColumnFamilies(
-      std::vector<std::string>(cf_names, cf_names + cf_count), option_vector);
+  ReopenWithColumnFamilies(std::vector<std::string>(cf_names,
+                                                    cf_names + cf_count),
+                           option_vector);
 
   port::Mutex mutex;
 
@@ -4948,7 +4962,7 @@ TEST_F(DBCompactionTest, CompactionLimiter) {
   // Enough L0 files to trigger compaction
   for (unsigned int cf = 0; cf < cf_count; cf++) {
     ASSERT_EQ(NumTableFilesAtLevel(0, cf),
-              options.level0_file_num_compaction_trigger);
+      options.level0_file_num_compaction_trigger);
   }
 
   // Create more files for one column family, which triggers speed up
@@ -4991,7 +5005,7 @@ TEST_F(DBCompactionTest, CompactionLimiter) {
 
   // flush one more file to cf 1
   for (int i = 0; i < kNumKeysPerFile; i++) {
-    ASSERT_OK(Put(cf_test, Key(keyIndex++), ""));
+      ASSERT_OK(Put(cf_test, Key(keyIndex++), ""));
   }
   // put extra key to trigger flush
   ASSERT_OK(Put(cf_test, "", ""));
@@ -5026,7 +5040,9 @@ TEST_P(DBCompactionDirectIOTest, DirectIO) {
       });
   if (options.use_direct_io_for_flush_and_compaction) {
     SyncPoint::GetInstance()->SetCallBack(
-        "SanitizeOptions:direct_io", [&](void* /*arg*/) { readahead = true; });
+        "SanitizeOptions:direct_io", [&](void* /*arg*/) {
+          readahead = true;
+        });
   }
   SyncPoint::GetInstance()->EnableProcessing();
   CreateAndReopenWithCF({"pikachu"}, options);
@@ -7347,8 +7363,8 @@ int main(int argc, char** argv) {
   ::testing::InitGoogleTest(&argc, argv);
   return RUN_ALL_TESTS();
 #else
-  (void)argc;
-  (void)argv;
+  (void) argc;
+  (void) argv;
   return 0;
 #endif
 }

--- a/db/db_compaction_test.cc
+++ b/db/db_compaction_test.cc
@@ -92,10 +92,7 @@ class SplitAllPartitioner : public SstPartitioner {
     return PartitionerResult::kRequired;
   }
 
-  bool CanDoTrivialMove(const Slice& smallest_user_key,
-                        const Slice& largest_user_key) {
-    return true;
-  }
+  bool CanDoTrivialMove(const Slice&, const Slice&) { return true; }
 };
 
 class SplitAllPatitionerFactory : public SstPartitionerFactory {

--- a/db/db_compaction_test.cc
+++ b/db/db_compaction_test.cc
@@ -83,6 +83,36 @@ class ChangeLevelConflictsWithAuto
 };
 
 namespace {
+class SplitAllPartitioner : public SstPartitioner {
+ public:
+  const char* Name() const override { return "SplitAllPartitioner"; }
+
+  PartitionerResult ShouldPartition(
+      const PartitionerRequest& /*request*/) override {
+    return PartitionerResult::kRequired;
+  }
+
+  bool CanDoTrivialMove(const Slice& smallest_user_key,
+                        const Slice& largest_user_key) {
+    return true;
+  }
+};
+
+class SplitAllPatitionerFactory : public SstPartitionerFactory {
+ public:
+  std::function<void(const SstPartitioner::Context&)> on_create_;
+
+  SplitAllPatitionerFactory(std::function<void(const SstPartitioner::Context&)> on_create) :
+    on_create_(on_create) {}
+
+  std::unique_ptr<SstPartitioner> CreatePartitioner(
+      const SstPartitioner::Context& context) const override {
+    on_create_(context);
+    return std::unique_ptr<SstPartitioner>(new SplitAllPartitioner());
+  }
+
+  const char* Name() const override { return "SplitAllPartitionerFactory"; }
+};
 
 class FlushedFileCollector : public EventListener {
  public:
@@ -1027,6 +1057,51 @@ TEST_F(DBCompactionTest, CompactionSstPartitionerNonTrivial) {
   ASSERT_EQ(2, files.size());
   ASSERT_EQ("A", Get("aaaa1"));
   ASSERT_EQ("B", Get("bbbb1"));
+}
+
+TEST_F(DBCompactionTest, CompactionSstPartitionerNextLevel) {
+  Options options = CurrentOptions();
+  options.compaction_style = kCompactionStyleLevel;
+  options.level0_file_num_compaction_trigger = 1;
+  options.max_bytes_for_level_base = 10;
+  options.max_bytes_for_level_multiplier = 2;
+  options.sst_partitioner_factory = std::unique_ptr<SstPartitionerFactory>(new SplitAllPatitionerFactory([this](const SstPartitioner::Context& cx) {
+    if (!cx.output_next_level_segments.empty()) {
+      std::vector<LiveFileMetaData> files;
+      // We are holding the mutex in this context...
+      // Perhaps we'd better make a `TEST_GetVersion` for fetching.
+      dbfull()->TEST_UnlockMutex();
+      dbfull()->GetLiveFilesMetaData(&files);
+      dbfull()->TEST_LockMutex();
+      auto next_level_overlap_files = std::count_if(files.begin(), files.end(), [&](const LiveFileMetaData& ld){
+        // Check whether the file is in range [cx.smallest_user_key, cx.largest_user_key) and in the level cx.output_level + 1.
+        return Slice(ld.smallestkey).compare(cx.largest_user_key) < 0 && Slice(ld.largestkey).compare(cx.smallest_user_key) > 0 && ld.level == cx.output_level + 1;
+      });
+      if (!cx.output_next_level_segments.empty()) {
+        ASSERT_EQ(next_level_overlap_files + 1, cx.output_next_level_segments.size());
+      }
+    }
+  }));
+  DestroyAndReopen(options);
+
+  ASSERT_OK(Put("A", "there are more than 10 bytes."));
+  ASSERT_OK(Put("B", "yet another key."));
+  ASSERT_OK(Flush());
+  ASSERT_OK(dbfull()->TEST_WaitForCompact(true));
+  ASSERT_OK(Put("A1", "the new challenger..."));
+  ASSERT_OK(Put("B1", "and his buddy."));
+  ASSERT_OK(Flush());
+  ASSERT_OK(dbfull()->TEST_WaitForFlushMemTable());
+  ASSERT_OK(dbfull()->TEST_WaitForCompact(true));
+  ASSERT_OK(Put("A1P", "the new challenger... Changed."));
+  ASSERT_OK(Put("B1P", "and his buddy. Changed too."));
+  ASSERT_OK(Flush());
+  ASSERT_OK(dbfull()->TEST_WaitForFlushMemTable());
+  ASSERT_OK(dbfull()->TEST_WaitForCompact(true));
+    
+  std::vector<LiveFileMetaData> files;
+  dbfull()->GetLiveFilesMetaData(&files);
+  ASSERT_EQ(6, files.size());
 }
 
 TEST_F(DBCompactionTest, ZeroSeqIdCompaction) {

--- a/db/db_compaction_test.cc
+++ b/db/db_compaction_test.cc
@@ -1074,23 +1074,26 @@ TEST_F(DBCompactionTest, CompactionSstPartitionerNextLevel) {
           dbfull()->TEST_LockMutex();
           std::vector<LiveFileMetaData> overlapped_files;
           std::copy_if(
-              files.begin(), files.end(), std::back_inserter(overlapped_files), [&](const LiveFileMetaData& ld) {
+              files.begin(), files.end(), std::back_inserter(overlapped_files),
+              [&](const LiveFileMetaData& ld) {
                 return Slice(ld.smallestkey).compare(cx.largest_user_key) < 0 &&
                        Slice(ld.largestkey).compare(cx.smallest_user_key) > 0 &&
                        ld.level == cx.output_level + 1;
               });
-          std::sort(overlapped_files.begin(), overlapped_files.end(), [](LiveFileMetaData& x, LiveFileMetaData& y) {
-            return x.largestkey < y.largestkey;
-          });
+          std::sort(overlapped_files.begin(), overlapped_files.end(),
+                    [](LiveFileMetaData& x, LiveFileMetaData& y) {
+                      return x.largestkey < y.largestkey;
+                    });
           auto next_level_overlap_files = overlapped_files.size();
           ASSERT_EQ(next_level_overlap_files + 1,
                     cx.output_next_level_boundaries.size());
           ASSERT_EQ(next_level_overlap_files, cx.output_next_level_size.size());
           ASSERT_EQ(next_level_overlap_files, cx.OutputNextLevelSegmentCount());
-          for (size_t i = 0; i < overlapped_files.size(); i ++) {
+          for (size_t i = 0; i < overlapped_files.size(); i++) {
             Slice next_level_lower, next_level_upper;
             int next_level_size;
-            cx.OutputNextLevelSegment(i, &next_level_lower, &next_level_upper, &next_level_size);
+            cx.OutputNextLevelSegment(i, &next_level_lower, &next_level_upper,
+                                      &next_level_size);
 
             if (i == 0) {
               ASSERT_EQ(overlapped_files[i].smallestkey, next_level_lower);
@@ -1116,8 +1119,10 @@ TEST_F(DBCompactionTest, CompactionSstPartitionerNextLevel) {
   ASSERT_OK(Flush());
   ASSERT_OK(dbfull()->TEST_WaitForFlushMemTable());
   ASSERT_OK(dbfull()->TEST_WaitForCompact(true));
-  ASSERT_OK(Put(InternalKey("A", 0, ValueType::kTypeDeletion).Encode(), "And a tricker: he pretends to be A, but not A."));
-  ASSERT_OK(Put(InternalKey("B", 0, ValueType::kTypeDeletion).Encode(), "Yeah, another tricker."));
+  ASSERT_OK(Put(InternalKey("A", 0, ValueType::kTypeDeletion).Encode(),
+                "And a tricker: he pretends to be A, but not A."));
+  ASSERT_OK(Put(InternalKey("B", 0, ValueType::kTypeDeletion).Encode(),
+                "Yeah, another tricker."));
   ASSERT_OK(Flush());
   ASSERT_OK(dbfull()->TEST_WaitForFlushMemTable());
   ASSERT_OK(dbfull()->TEST_WaitForCompact(true));

--- a/db/db_compaction_test.cc
+++ b/db/db_compaction_test.cc
@@ -99,8 +99,9 @@ class SplitAllPatitionerFactory : public SstPartitionerFactory {
  public:
   std::function<void(const SstPartitioner::Context&)> on_create_;
 
-  SplitAllPatitionerFactory(std::function<void(const SstPartitioner::Context&)> on_create) :
-    on_create_(on_create) {}
+  SplitAllPatitionerFactory(
+      std::function<void(const SstPartitioner::Context&)> on_create)
+      : on_create_(on_create) {}
 
   std::unique_ptr<SstPartitioner> CreatePartitioner(
       const SstPartitioner::Context& context) const override {
@@ -138,9 +139,10 @@ class FlushedFileCollector : public EventListener {
 };
 
 class CompactionStatsCollector : public EventListener {
-public:
+ public:
   CompactionStatsCollector()
-      : compaction_completed_(static_cast<int>(CompactionReason::kNumOfReasons)) {
+      : compaction_completed_(
+            static_cast<int>(CompactionReason::kNumOfReasons)) {
     for (auto& v : compaction_completed_) {
       v.store(0);
     }
@@ -174,7 +176,7 @@ public:
     return compaction_completed_.at(k).load();
   }
 
-private:
+ private:
   std::vector<std::atomic<int>> compaction_completed_;
 };
 
@@ -213,9 +215,8 @@ Options DeletionTriggerOptions(Options options) {
   return options;
 }
 
-bool HaveOverlappingKeyRanges(
-    const Comparator* c,
-    const SstFileMetaData& a, const SstFileMetaData& b) {
+bool HaveOverlappingKeyRanges(const Comparator* c, const SstFileMetaData& a,
+                              const SstFileMetaData& b) {
   if (c->CompareWithoutTimestamp(a.smallestkey, b.smallestkey) >= 0) {
     if (c->CompareWithoutTimestamp(a.smallestkey, b.largestkey) <= 0) {
       // b.smallestkey <= a.smallestkey <= b.largestkey
@@ -240,18 +241,15 @@ bool HaveOverlappingKeyRanges(
 // Identifies all files between level "min_level" and "max_level"
 // which has overlapping key range with "input_file_meta".
 void GetOverlappingFileNumbersForLevelCompaction(
-    const ColumnFamilyMetaData& cf_meta,
-    const Comparator* comparator,
-    int min_level, int max_level,
-    const SstFileMetaData* input_file_meta,
+    const ColumnFamilyMetaData& cf_meta, const Comparator* comparator,
+    int min_level, int max_level, const SstFileMetaData* input_file_meta,
     std::set<std::string>* overlapping_file_names) {
   std::set<const SstFileMetaData*> overlapping_files;
   overlapping_files.insert(input_file_meta);
   for (int m = min_level; m <= max_level; ++m) {
     for (auto& file : cf_meta.levels[m].files) {
       for (auto* included_file : overlapping_files) {
-        if (HaveOverlappingKeyRanges(
-                comparator, *included_file, file)) {
+        if (HaveOverlappingKeyRanges(comparator, *included_file, file)) {
           overlapping_files.insert(&file);
           overlapping_file_names->insert(file.name);
           break;
@@ -282,7 +280,7 @@ void VerifyCompactionResult(
  * 2) stat.counts[i] == collector.NumberOfCompactions(i)
  */
 void VerifyCompactionStats(ColumnFamilyData& cfd,
-    const CompactionStatsCollector& collector) {
+                           const CompactionStatsCollector& collector) {
 #ifndef NDEBUG
   InternalStats* internal_stats_ptr = cfd.internal_stats();
   ASSERT_NE(internal_stats_ptr, nullptr);
@@ -303,17 +301,15 @@ void VerifyCompactionStats(ColumnFamilyData& cfd,
   // Verify InternalStats bookkeeping matches that of CompactionStatsCollector,
   // assuming that all compactions complete.
   for (int i = 0; i < num_of_reasons; i++) {
-    ASSERT_EQ(collector.NumberOfCompactions(static_cast<CompactionReason>(i)), counts[i]);
+    ASSERT_EQ(collector.NumberOfCompactions(static_cast<CompactionReason>(i)),
+              counts[i]);
   }
 #endif /* NDEBUG */
 }
 
-const SstFileMetaData* PickFileRandomly(
-    const ColumnFamilyMetaData& cf_meta,
-    Random* rand,
-    int* level = nullptr) {
-  auto file_id = rand->Uniform(static_cast<int>(
-      cf_meta.file_count)) + 1;
+const SstFileMetaData* PickFileRandomly(const ColumnFamilyMetaData& cf_meta,
+                                        Random* rand, int* level = nullptr) {
+  auto file_id = rand->Uniform(static_cast<int>(cf_meta.file_count)) + 1;
   for (auto& level_meta : cf_meta.levels) {
     if (file_id <= level_meta.files.size()) {
       if (level != nullptr) {
@@ -740,7 +736,6 @@ TEST_F(DBCompactionTest, DisableStatsUpdateReopen) {
   }
 }
 
-
 TEST_P(DBCompactionTestWithParam, CompactionTrigger) {
   const int kNumKeysPerFile = 100;
 
@@ -883,7 +878,7 @@ TEST_F(DBCompactionTest, BGCompactionsAllowed) {
 
 TEST_P(DBCompactionTestWithParam, CompactionsGenerateMultipleFiles) {
   Options options = CurrentOptions();
-  options.write_buffer_size = 100000000;        // Large write buffer
+  options.write_buffer_size = 100000000;  // Large write buffer
   options.max_subcompactions = max_subcompactions_;
   CreateAndReopenWithCF({"pikachu"}, options);
 
@@ -1062,23 +1057,29 @@ TEST_F(DBCompactionTest, CompactionSstPartitionerNextLevel) {
   options.level0_file_num_compaction_trigger = 1;
   options.max_bytes_for_level_base = 10;
   options.max_bytes_for_level_multiplier = 2;
-  options.sst_partitioner_factory = std::unique_ptr<SstPartitionerFactory>(new SplitAllPatitionerFactory([this](const SstPartitioner::Context& cx) {
-    if (!cx.output_next_level_segments.empty()) {
-      std::vector<LiveFileMetaData> files;
-      // We are holding the mutex in this context...
-      // Perhaps we'd better make a `TEST_GetVersion` for fetching.
-      dbfull()->TEST_UnlockMutex();
-      dbfull()->GetLiveFilesMetaData(&files);
-      dbfull()->TEST_LockMutex();
-      auto next_level_overlap_files = std::count_if(files.begin(), files.end(), [&](const LiveFileMetaData& ld){
-        // Check whether the file is in range [cx.smallest_user_key, cx.largest_user_key) and in the level cx.output_level + 1.
-        return Slice(ld.smallestkey).compare(cx.largest_user_key) < 0 && Slice(ld.largestkey).compare(cx.smallest_user_key) > 0 && ld.level == cx.output_level + 1;
-      });
-      if (!cx.output_next_level_segments.empty()) {
-        ASSERT_EQ(next_level_overlap_files + 1, cx.output_next_level_segments.size());
-      }
-    }
-  }));
+  options.sst_partitioner_factory = std::unique_ptr<SstPartitionerFactory>(
+      new SplitAllPatitionerFactory([this](const SstPartitioner::Context& cx) {
+        if (!cx.output_next_level_segments.empty()) {
+          std::vector<LiveFileMetaData> files;
+          // We are holding the mutex in this context...
+          // Perhaps we'd better make a `TEST_GetVersion` for fetching.
+          dbfull()->TEST_UnlockMutex();
+          dbfull()->GetLiveFilesMetaData(&files);
+          dbfull()->TEST_LockMutex();
+          auto next_level_overlap_files = std::count_if(
+              files.begin(), files.end(), [&](const LiveFileMetaData& ld) {
+                // Check whether the file is in range [cx.smallest_user_key,
+                // cx.largest_user_key) and in the level cx.output_level + 1.
+                return Slice(ld.smallestkey).compare(cx.largest_user_key) < 0 &&
+                       Slice(ld.largestkey).compare(cx.smallest_user_key) > 0 &&
+                       ld.level == cx.output_level + 1;
+              });
+          if (!cx.output_next_level_segments.empty()) {
+            ASSERT_EQ(next_level_overlap_files + 1,
+                      cx.output_next_level_segments.size());
+          }
+        }
+      }));
   DestroyAndReopen(options);
 
   ASSERT_OK(Put("A", "there are more than 10 bytes."));
@@ -1095,7 +1096,7 @@ TEST_F(DBCompactionTest, CompactionSstPartitionerNextLevel) {
   ASSERT_OK(Flush());
   ASSERT_OK(dbfull()->TEST_WaitForFlushMemTable());
   ASSERT_OK(dbfull()->TEST_WaitForCompact(true));
-    
+
   std::vector<LiveFileMetaData> files;
   dbfull()->GetLiveFilesMetaData(&files);
   ASSERT_EQ(6, files.size());
@@ -1114,7 +1115,7 @@ TEST_F(DBCompactionTest, ZeroSeqIdCompaction) {
   compact_opt.compression = kNoCompression;
   compact_opt.output_file_size_limit = 4096;
   const size_t key_len =
-    static_cast<size_t>(compact_opt.output_file_size_limit) / 5;
+      static_cast<size_t>(compact_opt.output_file_size_limit) / 5;
 
   DestroyAndReopen(options);
 
@@ -1288,14 +1289,8 @@ TEST_P(DBCompactionTestWithParam, TrivialMoveNonOverlappingFiles) {
   DestroyAndReopen(options);
   // non overlapping ranges
   std::vector<std::pair<int32_t, int32_t>> ranges = {
-    {100, 199},
-    {300, 399},
-    {0, 99},
-    {200, 299},
-    {600, 699},
-    {400, 499},
-    {500, 550},
-    {551, 599},
+      {100, 199}, {300, 399}, {0, 99},    {200, 299},
+      {600, 699}, {400, 499}, {500, 550}, {551, 599},
   };
   int32_t value_size = 10 * 1024;  // 10 KB
 
@@ -1338,14 +1333,10 @@ TEST_P(DBCompactionTestWithParam, TrivialMoveNonOverlappingFiles) {
   DestroyAndReopen(options);
   // Same ranges as above but overlapping
   ranges = {
-    {100, 199},
-    {300, 399},
-    {0, 99},
-    {200, 299},
-    {600, 699},
-    {400, 499},
-    {500, 560},  // this range overlap with the next one
-    {551, 599},
+      {100, 199}, {300, 399}, {0, 99},    {200, 299},
+      {600, 699}, {400, 499}, {500, 560},  // this range overlap with the next
+                                           // one
+      {551, 599},
   };
   for (size_t i = 0; i < ranges.size(); i++) {
     for (int32_t j = ranges[i].first; j <= ranges[i].second; j++) {
@@ -1880,7 +1871,7 @@ TEST_F(DBCompactionTest, DeleteFilesInRanges) {
   ASSERT_EQ("0,0,10", FilesPerLevel(0));
 
   // file [0 => 100), [200 => 300), ... [800, 900)
-  for (auto i = 0; i < 10; i+=2) {
+  for (auto i = 0; i < 10; i += 2) {
     for (auto j = 0; j < 100; j++) {
       auto k = i * 100 + j;
       ASSERT_OK(Put(Key(k), values[k]));
@@ -2322,14 +2313,14 @@ TEST_P(DBCompactionTestWithParam, LevelCompactionCFPathUse) {
   cf_opt1.cf_paths.emplace_back(dbname_ + "cf1_2", 4 * 1024 * 1024);
   cf_opt1.cf_paths.emplace_back(dbname_ + "cf1_3", 1024 * 1024 * 1024);
   option_vector.emplace_back(DBOptions(options), cf_opt1);
-  CreateColumnFamilies({"one"},option_vector[1]);
+  CreateColumnFamilies({"one"}, option_vector[1]);
 
   // Configure CF2 specific paths.
   cf_opt2.cf_paths.emplace_back(dbname_ + "cf2", 500 * 1024);
   cf_opt2.cf_paths.emplace_back(dbname_ + "cf2_2", 4 * 1024 * 1024);
   cf_opt2.cf_paths.emplace_back(dbname_ + "cf2_3", 1024 * 1024 * 1024);
   option_vector.emplace_back(DBOptions(options), cf_opt2);
-  CreateColumnFamilies({"two"},option_vector[2]);
+  CreateColumnFamilies({"two"}, option_vector[2]);
 
   ReopenWithColumnFamilies({"default", "one", "two"}, option_vector);
 
@@ -2677,7 +2668,6 @@ TEST_P(DBCompactionTestWithParam, ManualCompaction) {
   }
 }
 
-
 TEST_P(DBCompactionTestWithParam, ManualLevelCompactionOutputPathId) {
   Options options = CurrentOptions();
   options.db_paths.emplace_back(dbname_ + "_2", 2 * 10485760);
@@ -2814,14 +2804,13 @@ TEST_P(DBCompactionTestWithParam, DISABLED_CompactFilesOnLevelCompaction) {
       auto file_meta = PickFileRandomly(cf_meta, &rnd, &level);
       compaction_input_file_names.push_back(file_meta->name);
       GetOverlappingFileNumbersForLevelCompaction(
-          cf_meta, options.comparator, level, output_level,
-          file_meta, &overlapping_file_names);
+          cf_meta, options.comparator, level, output_level, file_meta,
+          &overlapping_file_names);
     }
 
-    ASSERT_OK(dbfull()->CompactFiles(
-        CompactionOptions(), handles_[1],
-        compaction_input_file_names,
-        output_level));
+    ASSERT_OK(dbfull()->CompactFiles(CompactionOptions(), handles_[1],
+                                     compaction_input_file_names,
+                                     output_level));
 
     // Make sure all overlapping files do not exist after compaction
     dbfull()->GetColumnFamilyMetaData(handles_[1], &cf_meta);
@@ -2844,8 +2833,7 @@ TEST_P(DBCompactionTestWithParam, PartialCompactionFailure) {
   options.write_buffer_size = kKeysPerBuffer * kKvSize;
   options.max_write_buffer_number = 2;
   options.target_file_size_base =
-      options.write_buffer_size *
-      (options.max_write_buffer_number - 1);
+      options.write_buffer_size * (options.max_write_buffer_number - 1);
   options.level0_file_num_compaction_trigger = kNumL1Files;
   options.max_bytes_for_level_base =
       options.level0_file_num_compaction_trigger *
@@ -2865,10 +2853,9 @@ TEST_P(DBCompactionTestWithParam, PartialCompactionFailure) {
 
   DestroyAndReopen(options);
 
-  const int kNumInsertedKeys =
-      options.level0_file_num_compaction_trigger *
-      (options.max_write_buffer_number - 1) *
-      kKeysPerBuffer;
+  const int kNumInsertedKeys = options.level0_file_num_compaction_trigger *
+                               (options.max_write_buffer_number - 1) *
+                               kKeysPerBuffer;
 
   Random rnd(301);
   std::vector<std::string> keys;
@@ -3566,9 +3553,8 @@ TEST_F(DBCompactionTest, CompactFilesPendingL0Bug) {
   ASSERT_EQ(kNumL0Files, cf_meta.levels[0].files.size());
   std::vector<std::string> input_filenames;
   input_filenames.push_back(cf_meta.levels[0].files.front().name);
-  ASSERT_OK(dbfull()
-                  ->CompactFiles(CompactionOptions(), input_filenames,
-                                 0 /* output_level */));
+  ASSERT_OK(dbfull()->CompactFiles(CompactionOptions(), input_filenames,
+                                   0 /* output_level */));
   TEST_SYNC_POINT("DBCompactionTest::CompactFilesPendingL0Bug:ManualCompacted");
   ROCKSDB_NAMESPACE::SyncPoint::GetInstance()->DisableProcessing();
 }
@@ -4215,9 +4201,9 @@ TEST_F(DBCompactionTest, LevelPeriodicAndTtlCompaction) {
   const int kValueSize = 100;
 
   Options options = CurrentOptions();
-  options.ttl = 10 * 60 * 60;  // 10 hours
+  options.ttl = 10 * 60 * 60;                          // 10 hours
   options.periodic_compaction_seconds = 48 * 60 * 60;  // 2 days
-  options.max_open_files = -1;   // needed for both periodic and ttl compactions
+  options.max_open_files = -1;  // needed for both periodic and ttl compactions
   env_->SetMockSleep();
   options.env = env_;
 
@@ -4632,7 +4618,7 @@ TEST_F(DBCompactionTest, CompactRangeSkipFlushAfterDelay) {
        {"DBImpl::FlushMemTable:StallWaitDone", "CompactionJob::Run():End"}});
   ROCKSDB_NAMESPACE::SyncPoint::GetInstance()->EnableProcessing();
 
-  //used for the delayable flushes
+  // used for the delayable flushes
   FlushOptions flush_opts;
   flush_opts.allow_write_stall = true;
   for (int i = 0; i < kNumL0FilesLimit - 1; ++i) {
@@ -4651,7 +4637,8 @@ TEST_F(DBCompactionTest, CompactRangeSkipFlushAfterDelay) {
   ASSERT_OK(Put(ToString(0), rnd.RandomString(1024)));
   ASSERT_OK(dbfull()->Flush(flush_opts));
   ASSERT_OK(Put(ToString(0), rnd.RandomString(1024)));
-  TEST_SYNC_POINT("DBCompactionTest::CompactRangeSkipFlushAfterDelay:PostFlush");
+  TEST_SYNC_POINT(
+      "DBCompactionTest::CompactRangeSkipFlushAfterDelay:PostFlush");
   manual_compaction_thread.join();
 
   // If CompactRange's flush was skipped, the final Put above will still be
@@ -4852,10 +4839,10 @@ TEST_F(DBCompactionTest, CompactionLimiter) {
   }
 
   std::shared_ptr<ConcurrentTaskLimiter> unique_limiter(
-    NewConcurrentTaskLimiter("unique_limiter", -1));
+      NewConcurrentTaskLimiter("unique_limiter", -1));
 
-  const char* cf_names[] = {"default", "0", "1", "2", "3", "4", "5",
-    "6", "7", "8", "9", "a", "b", "c", "d", "e", "f" };
+  const char* cf_names[] = {"default", "0", "1", "2", "3", "4", "5", "6", "7",
+                            "8",       "9", "a", "b", "c", "d", "e", "f"};
   const unsigned int cf_count = sizeof cf_names / sizeof cf_names[0];
 
   std::unordered_map<std::string, CompactionLimiter*> cf_to_limiter;
@@ -4867,10 +4854,10 @@ TEST_F(DBCompactionTest, CompactionLimiter) {
   options.level0_file_num_compaction_trigger = 4;
   options.level0_slowdown_writes_trigger = 64;
   options.level0_stop_writes_trigger = 64;
-  options.max_background_jobs = kMaxBackgroundThreads; // Enough threads
+  options.max_background_jobs = kMaxBackgroundThreads;  // Enough threads
   options.memtable_factory.reset(
       test::NewSpecialSkipListFactory(kNumKeysPerFile));
-  options.max_write_buffer_number = 10; // Enough memtables
+  options.max_write_buffer_number = 10;  // Enough memtables
   DestroyAndReopen(options);
 
   std::vector<Options> option_vector;
@@ -4898,9 +4885,8 @@ TEST_F(DBCompactionTest, CompactionLimiter) {
     CreateColumnFamilies({cf_names[cf]}, option_vector[cf]);
   }
 
-  ReopenWithColumnFamilies(std::vector<std::string>(cf_names,
-                                                    cf_names + cf_count),
-                           option_vector);
+  ReopenWithColumnFamilies(
+      std::vector<std::string>(cf_names, cf_names + cf_count), option_vector);
 
   port::Mutex mutex;
 
@@ -4962,7 +4948,7 @@ TEST_F(DBCompactionTest, CompactionLimiter) {
   // Enough L0 files to trigger compaction
   for (unsigned int cf = 0; cf < cf_count; cf++) {
     ASSERT_EQ(NumTableFilesAtLevel(0, cf),
-      options.level0_file_num_compaction_trigger);
+              options.level0_file_num_compaction_trigger);
   }
 
   // Create more files for one column family, which triggers speed up
@@ -5005,7 +4991,7 @@ TEST_F(DBCompactionTest, CompactionLimiter) {
 
   // flush one more file to cf 1
   for (int i = 0; i < kNumKeysPerFile; i++) {
-      ASSERT_OK(Put(cf_test, Key(keyIndex++), ""));
+    ASSERT_OK(Put(cf_test, Key(keyIndex++), ""));
   }
   // put extra key to trigger flush
   ASSERT_OK(Put(cf_test, "", ""));
@@ -5040,9 +5026,7 @@ TEST_P(DBCompactionDirectIOTest, DirectIO) {
       });
   if (options.use_direct_io_for_flush_and_compaction) {
     SyncPoint::GetInstance()->SetCallBack(
-        "SanitizeOptions:direct_io", [&](void* /*arg*/) {
-          readahead = true;
-        });
+        "SanitizeOptions:direct_io", [&](void* /*arg*/) { readahead = true; });
   }
   SyncPoint::GetInstance()->EnableProcessing();
   CreateAndReopenWithCF({"pikachu"}, options);
@@ -7363,8 +7347,8 @@ int main(int argc, char** argv) {
   ::testing::InitGoogleTest(&argc, argv);
   return RUN_ALL_TESTS();
 #else
-  (void) argc;
-  (void) argv;
+  (void)argc;
+  (void)argv;
   return 0;
 #endif
 }

--- a/include/rocksdb/sst_partitioner.h
+++ b/include/rocksdb/sst_partitioner.h
@@ -82,10 +82,20 @@ class SstPartitioner {
     Slice smallest_user_key;
     // Largest key for compaction
     Slice largest_user_key;
+
     // The segments consist with the next level of target level.
     // This will be useful while deciding whether to partition
-    // files to finer parts for avoiding future huge compactions.
-    std::vector<Segment> output_next_level_segments;
+    // files to finer parts for avoiding possible huge compactions.
+
+    // The boundaries of the next level of output level.
+    // For example, when the next level contains files with range ("001",
+    // "002"), ("003", "004"), The boundaries will be ["001", "002", "004"];
+    std::vector<Slice> output_next_level_boundaries;
+    // The size of each segment, for example, when
+    // `output_next_level_boundaries` is ["001", "002", "004"], this might be
+    // [42, 96], which means range ["001", "002") contains 42 bytes of data,
+    // ["002", "004") contains 96 bytes of data.
+    std::vector<uint64_t> output_next_level_size;
   };
 };
 

--- a/include/rocksdb/sst_partitioner.h
+++ b/include/rocksdb/sst_partitioner.h
@@ -104,8 +104,8 @@ class SstPartitioner {
 
     // Helper function to fetch the n-th segment of the next level of the output
     // level. `index` shall less than `OutputNextLevelSegmentCount`.
-    void OutputNextLevelSegment(int index, Slice* smallest_key, Slice* largest_key,
-                                int* size) const {
+    void OutputNextLevelSegment(int index, Slice* smallest_key,
+                                Slice* largest_key, int* size) const {
       if (smallest_key != nullptr) {
         *smallest_key = output_next_level_boundaries[index];
       }

--- a/include/rocksdb/sst_partitioner.h
+++ b/include/rocksdb/sst_partitioner.h
@@ -62,6 +62,11 @@ class SstPartitioner {
   virtual bool CanDoTrivialMove(const Slice& smallest_user_key,
                                 const Slice& largest_user_key) = 0;
 
+  struct Segment {
+    int size_in_this_segment;
+    Slice segment_until_user_key;
+  };
+
   // Context information of a compaction run
   struct Context {
     // Does this compaction run include all data files
@@ -75,6 +80,10 @@ class SstPartitioner {
     Slice smallest_user_key;
     // Largest key for compaction
     Slice largest_user_key;
+    // The segments consist with the next level of target level.
+    // This will be useful while deciding whether to partition 
+    // files to finer parts for avoiding future huge compactions.
+    std::vector<Segment> output_next_level_segments;
   };
 };
 

--- a/include/rocksdb/sst_partitioner.h
+++ b/include/rocksdb/sst_partitioner.h
@@ -96,6 +96,25 @@ class SstPartitioner {
     // [42, 96], which means range ["001", "002") contains 42 bytes of data,
     // ["002", "004") contains 96 bytes of data.
     std::vector<uint64_t> output_next_level_size;
+
+    // Helper function to fetch the count of next level segments.
+    int OutputNextLevelSegmentCount() {
+      return output_next_level_boundaries.empty()
+                 ? 0
+                 : output_next_level_boundaries.size() - 1;
+    }
+
+    // Helper function to fetch the n-th segment of the next level of the output level.
+    // `index` shall less than `OutputNextLevelSegmentCount`.
+    void OutputNextLevelSegment(int index, Slice* start_key, Slice* end_key,
+                                int* size) {
+      assert(start_key != nullptr);
+      *start_key = output_next_level_boundaries[index];
+      assert(end_key != nullptr);
+      *end_key = output_next_level_boundaries[index + 1];
+      assert(size != nullptr);
+      *size = output_next_level_size[index];
+    }
   };
 };
 

--- a/include/rocksdb/sst_partitioner.h
+++ b/include/rocksdb/sst_partitioner.h
@@ -63,7 +63,8 @@ class SstPartitioner {
                                 const Slice& largest_user_key) = 0;
 
   struct Segment {
-    int size_in_this_segment;
+    Segment(uint64_t size_diff, Slice until) : size_in_this_segment(size_diff), segment_until_user_key(until) {}
+    uint64_t size_in_this_segment;
     Slice segment_until_user_key;
   };
 

--- a/include/rocksdb/sst_partitioner.h
+++ b/include/rocksdb/sst_partitioner.h
@@ -63,7 +63,8 @@ class SstPartitioner {
                                 const Slice& largest_user_key) = 0;
 
   struct Segment {
-    Segment(uint64_t size_diff, Slice until) : size_in_this_segment(size_diff), segment_until_user_key(until) {}
+    Segment(uint64_t size_diff, Slice until)
+        : size_in_this_segment(size_diff), segment_until_user_key(until) {}
     uint64_t size_in_this_segment;
     Slice segment_until_user_key;
   };
@@ -82,7 +83,7 @@ class SstPartitioner {
     // Largest key for compaction
     Slice largest_user_key;
     // The segments consist with the next level of target level.
-    // This will be useful while deciding whether to partition 
+    // This will be useful while deciding whether to partition
     // files to finer parts for avoiding future huge compactions.
     std::vector<Segment> output_next_level_segments;
   };

--- a/include/rocksdb/sst_partitioner.h
+++ b/include/rocksdb/sst_partitioner.h
@@ -98,22 +98,23 @@ class SstPartitioner {
     std::vector<uint64_t> output_next_level_size;
 
     // Helper function to fetch the count of next level segments.
-    int OutputNextLevelSegmentCount() {
-      return output_next_level_boundaries.empty()
-                 ? 0
-                 : output_next_level_boundaries.size() - 1;
+    int OutputNextLevelSegmentCount() const {
+      return output_next_level_size.size();
     }
 
-    // Helper function to fetch the n-th segment of the next level of the output level.
-    // `index` shall less than `OutputNextLevelSegmentCount`.
-    void OutputNextLevelSegment(int index, Slice* start_key, Slice* end_key,
-                                int* size) {
-      assert(start_key != nullptr);
-      *start_key = output_next_level_boundaries[index];
-      assert(end_key != nullptr);
-      *end_key = output_next_level_boundaries[index + 1];
-      assert(size != nullptr);
-      *size = output_next_level_size[index];
+    // Helper function to fetch the n-th segment of the next level of the output
+    // level. `index` shall less than `OutputNextLevelSegmentCount`.
+    void OutputNextLevelSegment(int index, Slice* smallest_key, Slice* largest_key,
+                                int* size) const {
+      if (smallest_key != nullptr) {
+        *smallest_key = output_next_level_boundaries[index];
+      }
+      if (largest_key != nullptr) {
+        *largest_key = output_next_level_boundaries[index + 1];
+      }
+      if (size != nullptr) {
+        *size = output_next_level_size[index];
+      }
     }
   };
 };

--- a/include/rocksdb/sst_partitioner.h
+++ b/include/rocksdb/sst_partitioner.h
@@ -63,8 +63,7 @@ class SstPartitioner {
                                 const Slice& largest_user_key) = 0;
 
   struct Segment {
-    Segment(uint64_t size_diff, Slice until)
-        : size_in_this_segment(size_diff), segment_until_user_key(until) {}
+    Segment(uint64_t size_diff, Slice until) : size_in_this_segment(size_diff), segment_until_user_key(until) {}
     uint64_t size_in_this_segment;
     Slice segment_until_user_key;
   };
@@ -83,7 +82,7 @@ class SstPartitioner {
     // Largest key for compaction
     Slice largest_user_key;
     // The segments consist with the next level of target level.
-    // This will be useful while deciding whether to partition
+    // This will be useful while deciding whether to partition 
     // files to finer parts for avoiding future huge compactions.
     std::vector<Segment> output_next_level_segments;
   };


### PR DESCRIPTION
This PR added a fields describing the overlapped file info of "next level of output level" (i.e. `output_level + 1`) info to the partitioner factory if there is.