### PR TITLE
Add copy constructor to ColumnFamilyHandleImpl

### DIFF
--- a/db/column_family.cc
+++ b/db/column_family.cc
@@ -51,12 +51,12 @@ ColumnFamilyHandleImpl::ColumnFamilyHandleImpl(
 }
 
 ColumnFamilyHandleImpl::ColumnFamilyHandleImpl(ColumnFamilyHandleImpl&& other) {
-  other.cfd_ = cfd_;
-  other.db_ = db_;
-  other.mutex_ = mutex_;
-  cfd_ = nullptr;
-  db_ = nullptr;
-  mutex_ = nullptr;
+  cfd_ = other.cfd_;
+  db_ = other.db_;
+  mutex_ = other.mutex_;
+  other.cfd_ = nullptr;
+  other.db_ = nullptr;
+  other.mutex_ = nullptr;
 }
 
 ColumnFamilyHandleImpl::~ColumnFamilyHandleImpl() {

--- a/db/column_family.cc
+++ b/db/column_family.cc
@@ -50,13 +50,10 @@ ColumnFamilyHandleImpl::ColumnFamilyHandleImpl(
   }
 }
 
-ColumnFamilyHandleImpl::ColumnFamilyHandleImpl(ColumnFamilyHandleImpl&& other) {
-  cfd_ = other.cfd_;
-  db_ = other.db_;
-  mutex_ = other.mutex_;
-  other.cfd_ = nullptr;
-  other.db_ = nullptr;
-  other.mutex_ = nullptr;
+ColumnFamilyHandleImpl::ColumnFamilyHandleImpl(
+  const ColumnFamilyHandleImpl& other)
+  : cfd_(other.cfd_), db_(other.db_), mutex_(other.mutex_) {
+    cfd_->Ref();
 }
 
 ColumnFamilyHandleImpl::~ColumnFamilyHandleImpl() {

--- a/db/column_family.cc
+++ b/db/column_family.cc
@@ -51,9 +51,9 @@ ColumnFamilyHandleImpl::ColumnFamilyHandleImpl(
 }
 
 ColumnFamilyHandleImpl::ColumnFamilyHandleImpl(
-  const ColumnFamilyHandleImpl& other)
-  : cfd_(other.cfd_), db_(other.db_), mutex_(other.mutex_) {
-    cfd_->Ref();
+    const ColumnFamilyHandleImpl& other)
+    : cfd_(other.cfd_), db_(other.db_), mutex_(other.mutex_) {
+  cfd_->Ref();
 }
 
 ColumnFamilyHandleImpl::~ColumnFamilyHandleImpl() {

--- a/db/column_family.cc
+++ b/db/column_family.cc
@@ -50,8 +50,7 @@ ColumnFamilyHandleImpl::ColumnFamilyHandleImpl(
   }
 }
 
-ColumnFamilyHandleImpl::ColumnFamilyHandleImpl(
-    ColumnFamilyHandleImpl&& other) {
+ColumnFamilyHandleImpl::ColumnFamilyHandleImpl(ColumnFamilyHandleImpl&& other) {
   other.cfd_ = cfd_;
   other.db_ = db_;
   other.mutex_ = mutex_;

--- a/db/column_family.cc
+++ b/db/column_family.cc
@@ -49,6 +49,7 @@ ColumnFamilyHandleImpl::ColumnFamilyHandleImpl(
     cfd_->Ref();
   }
 }
+
 ColumnFamilyHandleImpl::ColumnFamilyHandleImpl(
     const ColumnFamilyHandleImpl& other)
     : cfd_(other.cfd_), db_(other.db_), mutex_(other.mutex_) {
@@ -195,7 +196,8 @@ Status CheckCFPathsSupported(const DBOptions& db_options,
       return Status::NotSupported(
           "More than one CF paths are only supported in "
           "universal and level compaction styles. ");
-    } else if (cf_options.cf_paths.empty() && db_options.db_paths.size() > 1) {
+    } else if (cf_options.cf_paths.empty() &&
+               db_options.db_paths.size() > 1) {
       return Status::NotSupported(
           "More than one DB paths are only supported in "
           "universal and level compaction styles. ");
@@ -341,8 +343,7 @@ ColumnFamilyOptions SanitizeOptions(const ImmutableDBOptions& db_options,
   // were not deleted yet, when we open the DB we will find these .trash files
   // and schedule them to be deleted (or delete immediately if SstFileManager
   // was not used)
-  auto sfm =
-      static_cast<SstFileManagerImpl*>(db_options.sst_file_manager.get());
+  auto sfm = static_cast<SstFileManagerImpl*>(db_options.sst_file_manager.get());
   for (size_t i = 0; i < result.cf_paths.size(); i++) {
     DeleteScheduler::CleanupDirectory(db_options.env, sfm,
                                       result.cf_paths[i].path)
@@ -595,8 +596,8 @@ ColumnFamilyData::ColumnFamilyData(
       compaction_picker_.reset(
           new FIFOCompactionPicker(ioptions_, &internal_comparator_));
     } else if (ioptions_.compaction_style == kCompactionStyleNone) {
-      compaction_picker_.reset(
-          new NullCompactionPicker(ioptions_, &internal_comparator_));
+      compaction_picker_.reset(new NullCompactionPicker(
+          ioptions_, &internal_comparator_));
       ROCKS_LOG_WARN(ioptions_.logger,
                      "Column family %s does not use any background compaction. "
                      "Compactions can only be done via CompactFiles\n",
@@ -984,8 +985,7 @@ WriteStallCondition ColumnFamilyData::RecalculateWriteStallConditions(
           mutable_cf_options.hard_pending_compaction_bytes_limit > 0 &&
           (compaction_needed_bytes -
            mutable_cf_options.soft_pending_compaction_bytes_limit) >
-              3 *
-                  (mutable_cf_options.hard_pending_compaction_bytes_limit -
+              3 * (mutable_cf_options.hard_pending_compaction_bytes_limit -
                    mutable_cf_options.soft_pending_compaction_bytes_limit) /
                   4;
 
@@ -1387,8 +1387,8 @@ bool ColumnFamilyData::ReturnThreadLocalSuperVersion(SuperVersion* sv) {
   return false;
 }
 
-void ColumnFamilyData::InstallSuperVersion(SuperVersionContext* sv_context,
-                                           InstrumentedMutex* db_mutex) {
+void ColumnFamilyData::InstallSuperVersion(
+    SuperVersionContext* sv_context, InstrumentedMutex* db_mutex) {
   db_mutex->AssertHeld();
   return InstallSuperVersion(sv_context, mutable_cf_options_);
 }
@@ -1554,8 +1554,8 @@ Env::WriteLifeTimeHint ColumnFamilyData::CalculateSSTWriteHint(int level) {
     // than base_level.
     return Env::WLTH_MEDIUM;
   }
-  return static_cast<Env::WriteLifeTimeHint>(
-      level - base_level + static_cast<int>(Env::WLTH_MEDIUM));
+  return static_cast<Env::WriteLifeTimeHint>(level - base_level +
+                            static_cast<int>(Env::WLTH_MEDIUM));
 }
 
 Status ColumnFamilyData::AddDirectories(
@@ -1649,8 +1649,8 @@ ColumnFamilyData* ColumnFamilySet::GetColumnFamily(uint32_t id) const {
   }
 }
 
-ColumnFamilyData* ColumnFamilySet::GetColumnFamily(
-    const std::string& name) const {
+ColumnFamilyData* ColumnFamilySet::GetColumnFamily(const std::string& name)
+    const {
   auto cfd_iter = column_families_.find(name);
   if (cfd_iter != column_families_.end()) {
     auto cfd = GetColumnFamily(cfd_iter->second);

--- a/db/column_family.cc
+++ b/db/column_family.cc
@@ -49,6 +49,13 @@ ColumnFamilyHandleImpl::ColumnFamilyHandleImpl(
     cfd_->Ref();
   }
 }
+ColumnFamilyHandleImpl::ColumnFamilyHandleImpl(
+    const ColumnFamilyHandleImpl& other)
+    : cfd_(other.cfd_), db_(other.db_), mutex_(other.mutex_) {
+  if (cfd_ != nullptr) {
+    cfd_->Ref();
+  }
+}
 
 ColumnFamilyHandleImpl::~ColumnFamilyHandleImpl() {
   if (cfd_ != nullptr) {
@@ -188,8 +195,7 @@ Status CheckCFPathsSupported(const DBOptions& db_options,
       return Status::NotSupported(
           "More than one CF paths are only supported in "
           "universal and level compaction styles. ");
-    } else if (cf_options.cf_paths.empty() &&
-               db_options.db_paths.size() > 1) {
+    } else if (cf_options.cf_paths.empty() && db_options.db_paths.size() > 1) {
       return Status::NotSupported(
           "More than one DB paths are only supported in "
           "universal and level compaction styles. ");
@@ -335,7 +341,8 @@ ColumnFamilyOptions SanitizeOptions(const ImmutableDBOptions& db_options,
   // were not deleted yet, when we open the DB we will find these .trash files
   // and schedule them to be deleted (or delete immediately if SstFileManager
   // was not used)
-  auto sfm = static_cast<SstFileManagerImpl*>(db_options.sst_file_manager.get());
+  auto sfm =
+      static_cast<SstFileManagerImpl*>(db_options.sst_file_manager.get());
   for (size_t i = 0; i < result.cf_paths.size(); i++) {
     DeleteScheduler::CleanupDirectory(db_options.env, sfm,
                                       result.cf_paths[i].path)
@@ -588,8 +595,8 @@ ColumnFamilyData::ColumnFamilyData(
       compaction_picker_.reset(
           new FIFOCompactionPicker(ioptions_, &internal_comparator_));
     } else if (ioptions_.compaction_style == kCompactionStyleNone) {
-      compaction_picker_.reset(new NullCompactionPicker(
-          ioptions_, &internal_comparator_));
+      compaction_picker_.reset(
+          new NullCompactionPicker(ioptions_, &internal_comparator_));
       ROCKS_LOG_WARN(ioptions_.logger,
                      "Column family %s does not use any background compaction. "
                      "Compactions can only be done via CompactFiles\n",
@@ -977,7 +984,8 @@ WriteStallCondition ColumnFamilyData::RecalculateWriteStallConditions(
           mutable_cf_options.hard_pending_compaction_bytes_limit > 0 &&
           (compaction_needed_bytes -
            mutable_cf_options.soft_pending_compaction_bytes_limit) >
-              3 * (mutable_cf_options.hard_pending_compaction_bytes_limit -
+              3 *
+                  (mutable_cf_options.hard_pending_compaction_bytes_limit -
                    mutable_cf_options.soft_pending_compaction_bytes_limit) /
                   4;
 
@@ -1379,8 +1387,8 @@ bool ColumnFamilyData::ReturnThreadLocalSuperVersion(SuperVersion* sv) {
   return false;
 }
 
-void ColumnFamilyData::InstallSuperVersion(
-    SuperVersionContext* sv_context, InstrumentedMutex* db_mutex) {
+void ColumnFamilyData::InstallSuperVersion(SuperVersionContext* sv_context,
+                                           InstrumentedMutex* db_mutex) {
   db_mutex->AssertHeld();
   return InstallSuperVersion(sv_context, mutable_cf_options_);
 }
@@ -1546,8 +1554,8 @@ Env::WriteLifeTimeHint ColumnFamilyData::CalculateSSTWriteHint(int level) {
     // than base_level.
     return Env::WLTH_MEDIUM;
   }
-  return static_cast<Env::WriteLifeTimeHint>(level - base_level +
-                            static_cast<int>(Env::WLTH_MEDIUM));
+  return static_cast<Env::WriteLifeTimeHint>(
+      level - base_level + static_cast<int>(Env::WLTH_MEDIUM));
 }
 
 Status ColumnFamilyData::AddDirectories(
@@ -1641,8 +1649,8 @@ ColumnFamilyData* ColumnFamilySet::GetColumnFamily(uint32_t id) const {
   }
 }
 
-ColumnFamilyData* ColumnFamilySet::GetColumnFamily(const std::string& name)
-    const {
+ColumnFamilyData* ColumnFamilySet::GetColumnFamily(
+    const std::string& name) const {
   auto cfd_iter = column_families_.find(name);
   if (cfd_iter != column_families_.end()) {
     auto cfd = GetColumnFamily(cfd_iter->second);

--- a/db/column_family.cc
+++ b/db/column_family.cc
@@ -53,7 +53,9 @@ ColumnFamilyHandleImpl::ColumnFamilyHandleImpl(
 ColumnFamilyHandleImpl::ColumnFamilyHandleImpl(
     const ColumnFamilyHandleImpl& other)
     : cfd_(other.cfd_), db_(other.db_), mutex_(other.mutex_) {
-  cfd_->Ref();
+  if (cfd_ != nullptr) {
+    cfd_->Ref();
+  }
 }
 
 ColumnFamilyHandleImpl::~ColumnFamilyHandleImpl() {

--- a/db/column_family.cc
+++ b/db/column_family.cc
@@ -51,11 +51,13 @@ ColumnFamilyHandleImpl::ColumnFamilyHandleImpl(
 }
 
 ColumnFamilyHandleImpl::ColumnFamilyHandleImpl(
-    const ColumnFamilyHandleImpl& other)
-    : cfd_(other.cfd_), db_(other.db_), mutex_(other.mutex_) {
-  if (cfd_ != nullptr) {
-    cfd_->Ref();
-  }
+    ColumnFamilyHandleImpl&& other) {
+  other.cfd_ = cfd_;
+  other.db_ = db_;
+  other.mutex_ = mutex_;
+  cfd_ = nullptr;
+  db_ = nullptr;
+  mutex_ = nullptr;
 }
 
 ColumnFamilyHandleImpl::~ColumnFamilyHandleImpl() {

--- a/db/column_family.h
+++ b/db/column_family.h
@@ -9,10 +9,10 @@
 
 #pragma once
 
-#include <unordered_map>
-#include <string>
-#include <vector>
 #include <atomic>
+#include <string>
+#include <unordered_map>
+#include <vector>
 
 #include "db/memtable_list.h"
 #include "db/table_cache.h"
@@ -160,8 +160,9 @@ extern const double kIncSlowdownRatio;
 class ColumnFamilyHandleImpl : public ColumnFamilyHandle {
  public:
   // create while holding the mutex
-  ColumnFamilyHandleImpl(
-      ColumnFamilyData* cfd, DBImpl* db, InstrumentedMutex* mutex);
+  ColumnFamilyHandleImpl(ColumnFamilyData* cfd, DBImpl* db,
+                         InstrumentedMutex* mutex);
+  ColumnFamilyHandleImpl(const ColumnFamilyHandleImpl& other);
   // destroy without mutex
   virtual ~ColumnFamilyHandleImpl();
   virtual ColumnFamilyData* cfd() const { return cfd_; }
@@ -186,7 +187,8 @@ class ColumnFamilyHandleImpl : public ColumnFamilyHandle {
 class ColumnFamilyHandleInternal : public ColumnFamilyHandleImpl {
  public:
   ColumnFamilyHandleInternal()
-      : ColumnFamilyHandleImpl(nullptr, nullptr, nullptr), internal_cfd_(nullptr) {}
+      : ColumnFamilyHandleImpl(nullptr, nullptr, nullptr),
+        internal_cfd_(nullptr) {}
 
   void SetCFD(ColumnFamilyData* _cfd) { internal_cfd_ = _cfd; }
   virtual ColumnFamilyData* cfd() const override { return internal_cfd_; }
@@ -354,7 +356,7 @@ class ColumnFamilyData {
   Version* current() { return current_; }
   Version* dummy_versions() { return dummy_versions_; }
   void SetCurrent(Version* _current);
-  uint64_t GetNumLiveVersions() const;  // REQUIRE: DB mutex held
+  uint64_t GetNumLiveVersions() const;    // REQUIRE: DB mutex held
   uint64_t GetTotalSstFilesSize() const;  // REQUIRE: DB mutex held
   uint64_t GetLiveSstFilesSize() const;   // REQUIRE: DB mutex held
   uint64_t GetTotalBlobFileSize() const;  // REQUIRE: DB mutex held
@@ -550,7 +552,7 @@ class ColumnFamilyData {
   Version* dummy_versions_;  // Head of circular doubly-linked list of versions.
   Version* current_;         // == dummy_versions->prev_
 
-  std::atomic<int> refs_;      // outstanding references to ColumnFamilyData
+  std::atomic<int> refs_;  // outstanding references to ColumnFamilyData
   std::atomic<bool> initialized_;
   std::atomic<bool> dropped_;  // true if client dropped it
 
@@ -648,8 +650,7 @@ class ColumnFamilySet {
   // ColumnFamilySet supports iteration
   class iterator {
    public:
-    explicit iterator(ColumnFamilyData* cfd)
-        : current_(cfd) {}
+    explicit iterator(ColumnFamilyData* cfd) : current_(cfd) {}
     // NOTE: minimum operators for for-loop iteration
     iterator& operator++() {
       current_ = current_->next_;

--- a/db/column_family.h
+++ b/db/column_family.h
@@ -9,10 +9,10 @@
 
 #pragma once
 
-#include <atomic>
-#include <string>
 #include <unordered_map>
+#include <string>
 #include <vector>
+#include <atomic>
 
 #include "db/memtable_list.h"
 #include "db/table_cache.h"
@@ -160,8 +160,8 @@ extern const double kIncSlowdownRatio;
 class ColumnFamilyHandleImpl : public ColumnFamilyHandle {
  public:
   // create while holding the mutex
-  ColumnFamilyHandleImpl(ColumnFamilyData* cfd, DBImpl* db,
-                         InstrumentedMutex* mutex);
+  ColumnFamilyHandleImpl(
+      ColumnFamilyData* cfd, DBImpl* db, InstrumentedMutex* mutex);
   ColumnFamilyHandleImpl(const ColumnFamilyHandleImpl& other);
   // destroy without mutex
   virtual ~ColumnFamilyHandleImpl();
@@ -187,8 +187,7 @@ class ColumnFamilyHandleImpl : public ColumnFamilyHandle {
 class ColumnFamilyHandleInternal : public ColumnFamilyHandleImpl {
  public:
   ColumnFamilyHandleInternal()
-      : ColumnFamilyHandleImpl(nullptr, nullptr, nullptr),
-        internal_cfd_(nullptr) {}
+      : ColumnFamilyHandleImpl(nullptr, nullptr, nullptr), internal_cfd_(nullptr) {}
 
   void SetCFD(ColumnFamilyData* _cfd) { internal_cfd_ = _cfd; }
   virtual ColumnFamilyData* cfd() const override { return internal_cfd_; }
@@ -356,7 +355,7 @@ class ColumnFamilyData {
   Version* current() { return current_; }
   Version* dummy_versions() { return dummy_versions_; }
   void SetCurrent(Version* _current);
-  uint64_t GetNumLiveVersions() const;    // REQUIRE: DB mutex held
+  uint64_t GetNumLiveVersions() const;  // REQUIRE: DB mutex held
   uint64_t GetTotalSstFilesSize() const;  // REQUIRE: DB mutex held
   uint64_t GetLiveSstFilesSize() const;   // REQUIRE: DB mutex held
   uint64_t GetTotalBlobFileSize() const;  // REQUIRE: DB mutex held
@@ -552,7 +551,7 @@ class ColumnFamilyData {
   Version* dummy_versions_;  // Head of circular doubly-linked list of versions.
   Version* current_;         // == dummy_versions->prev_
 
-  std::atomic<int> refs_;  // outstanding references to ColumnFamilyData
+  std::atomic<int> refs_;      // outstanding references to ColumnFamilyData
   std::atomic<bool> initialized_;
   std::atomic<bool> dropped_;  // true if client dropped it
 
@@ -650,7 +649,8 @@ class ColumnFamilySet {
   // ColumnFamilySet supports iteration
   class iterator {
    public:
-    explicit iterator(ColumnFamilyData* cfd) : current_(cfd) {}
+    explicit iterator(ColumnFamilyData* cfd)
+        : current_(cfd) {}
     // NOTE: minimum operators for for-loop iteration
     iterator& operator++() {
       current_ = current_->next_;

--- a/db/column_family.h
+++ b/db/column_family.h
@@ -162,7 +162,7 @@ class ColumnFamilyHandleImpl : public ColumnFamilyHandle {
   // create while holding the mutex
   ColumnFamilyHandleImpl(
       ColumnFamilyData* cfd, DBImpl* db, InstrumentedMutex* mutex);
-  ColumnFamilyHandleImpl(const ColumnFamilyHandleImpl& other);
+  ColumnFamilyHandleImpl(ColumnFamilyHandleImpl&& other);
   // destroy without mutex
   virtual ~ColumnFamilyHandleImpl();
   virtual ColumnFamilyData* cfd() const { return cfd_; }

--- a/db/column_family.h
+++ b/db/column_family.h
@@ -162,7 +162,7 @@ class ColumnFamilyHandleImpl : public ColumnFamilyHandle {
   // create while holding the mutex
   ColumnFamilyHandleImpl(
       ColumnFamilyData* cfd, DBImpl* db, InstrumentedMutex* mutex);
-  ColumnFamilyHandleImpl(ColumnFamilyHandleImpl&& other);
+  ColumnFamilyHandleImpl(const ColumnFamilyHandleImpl& other);
   // destroy without mutex
   virtual ~ColumnFamilyHandleImpl();
   virtual ColumnFamilyData* cfd() const { return cfd_; }


### PR DESCRIPTION
Ref https://github.com/tikv/titan/issues/294

This is needed by https://github.com/tikv/titan/pull/298.
In that PR, we need to create Titan's own `ColumnFamiliyHandle` instances. To avoid memory leak, we need to delete `ColumnFamilyHandleImpl` instances created by RocksDB itself. 