### PR TITLE
Get table prop from table cache without IO

### DIFF
--- a/db/compaction/compaction.cc
+++ b/db/compaction/compaction.cc
@@ -554,8 +554,7 @@ std::unique_ptr<CompactionFilter> Compaction::CreateCompactionFilter(
   for (auto l = inputs_.begin(); l != inputs_.end(); ++l) {
     for (auto f = l->files.begin(); f != l->files.end(); ++f) {
       std::shared_ptr<const TableProperties> tp;
-      Status s =
-          input_version_->GetTableProperties(&tp, *f, nullptr, false /*no_io*/);
+      Status s = input_version_->GetTableProperties(&tp, *f, nullptr);
       assert(s.ok());
       context.file_numbers.push_back((*f)->fd.GetNumber());
       context.table_properties.push_back(tp);


### PR DESCRIPTION
I confirmed with the author that the change `no_io = false` made in https://github.com/tikv/rocksdb/pull/211 was not intended as the PR description suggested.

If `no_io` is set to true, `TableCache` would not load the table and add it to the cache, when the table does not exist in the cache already, instead, the caller (in this case, `Version` which is then called by compaction) is responsible to load the table properties without affecting the cache. Since compaction is an one-off operation (from SST's perspective), it makes more sense to set `no_io` to true here. 