### PR TITLE
Add `is_bottommost_level` in compaction filter context

### DIFF
--- a/db/compaction/compaction.cc
+++ b/db/compaction/compaction.cc
@@ -827,6 +827,7 @@ std::unique_ptr<CompactionFilter> Compaction::CreateCompactionFilter() const {
   context.is_full_compaction = is_full_compaction_;
   context.is_manual_compaction = is_manual_compaction_;
   context.input_start_level = start_level_;
+  context.is_bottommost_level = bottommost_level_;
   context.column_family_id = cfd_->GetID();
   context.reason = TableFileCreationReason::kCompaction;
   context.input_table_properties = GetInputTableProperties();

--- a/include/rocksdb/compaction_filter.h
+++ b/include/rocksdb/compaction_filter.h
@@ -164,6 +164,8 @@ class CompactionFilter : public Customizable {
     // The lowest level among all the input files (if any) used in table
     // creation
     int input_start_level = kUnknownStartLevel;
+    // Whether output files are in bottommost level or not.
+    bool is_bottommost_level;
     // The column family that will contain the created table file.
     uint32_t column_family_id;
     // Reason this table file is being created.


### PR DESCRIPTION
This is a cherry-pick of https://github.com/tikv/rocksdb/commit/8e203492b81af0df1cbda907d5f0e8fbaf13d266

Adding `is_bottommost_level` info, so that MVCC storage engine built on top of RocksDB can decide whether to GC tombstones during compaction. i.e. If the compaction involves the bottommost level, tombstones can be discarded, otherwise, they need to be kept in order to GC old versions in the lower levels in the future.

We had 2 other compaction filter related changes but are no longer needed now: 
* https://github.com/tikv/rocksdb/commit/9554ad2b3fa7de8928054bfb30c2fcd6e714c50e range is no longer need, table properties are populated by a different field called `input_table_properties` in `CompactionFilter::Context`
* https://github.com/tikv/rocksdb/commit/3a238bf6f367b5ee76de9c497eba823c0e156ead <- no longer needed, see the comment in https://github.com/tikv/tikv/pull/9694