### PR TITLE
Enrich write batch

### DIFF
--- a/db/write_batch_internal.h
+++ b/db/write_batch_internal.h
@@ -211,6 +211,8 @@ class WriteBatchInternal {
   static Status Append(WriteBatch* dst, const WriteBatch* src,
                        const bool WAL_only = false);
 
+  static Status AppendContents(WriteBatch* dst, const Slice& content);
+
   // Returns the byte size of appending a WriteBatch with ByteSize
   // leftByteSize and a WriteBatch with ByteSize rightByteSize
   static size_t AppendedByteSize(size_t leftByteSize, size_t rightByteSize);

--- a/include/rocksdb/write_batch.h
+++ b/include/rocksdb/write_batch.h
@@ -368,6 +368,8 @@ class WriteBatch : public WriteBatchBase {
     }
   };
   Status Iterate(Handler* handler) const;
+  class Iterator;
+  Iterator* NewIterator() const { return new Iterator(rep_); }
 
   // Retrieve the serialized version of this batch.
   const std::string& Data() const { return rep_; }
@@ -506,6 +508,44 @@ class WriteBatch : public WriteBatchBase {
 
  protected:
   std::string rep_;  // See comment in write_batch.cc for the format of rep_
+ public:
+  class Iterator {
+   private:
+    Slice rep_;
+    Slice input_;
+    Slice key_;
+    Slice value_;
+    uint32_t column_family_;
+    char tag_;
+    bool valid_;
+
+   public:
+    explicit Iterator(const Slice& rep) : rep_(rep), valid_(false) {}
+
+    bool Valid() const { return valid_; }
+
+    Slice Key() const { return key_; }
+
+    Slice Value() const { return value_; }
+
+    uint32_t GetColumnFamilyId() const { return column_family_; }
+
+    char GetValueType() const { return tag_; };
+
+    void SeekToFirst();
+
+    void Next();
+  };
+  class WriteBatchRef {
+   public:
+    explicit WriteBatchRef(const Slice& rep) : rep_(rep) {}
+    Iterator* NewIterator() const { return new Iterator(rep_); }
+
+    int Count() const;
+
+   private:
+    const Slice& rep_;
+  };
 };
 
 }  // namespace ROCKSDB_NAMESPACE


### PR DESCRIPTION
This is a cherry-pick of https://github.com/tikv/rocksdb/pull/177

Adding `WriteBatch::Iterator` and `WriteBatchInternal:: AppendContents()`.

`WriteBatchInternal::AppendContents()` is used by TiKV to efficiently merge multiple write batches into a larger batch, thereby reducing overhead. This operation is particularly useful for avoiding unnecessary memory copies or decoding of data.

`WriteBatch::Iterator` is not being directly used by TiKV. But it is still kept.