### PR TITLE
Fix ingestion level selection

### DIFF
--- a/db/db_impl/db_impl.cc
+++ b/db/db_impl/db_impl.cc
@@ -6458,6 +6458,7 @@ void DBImpl::NotifyOnExternalFileIngested(
     info.internal_file_path = f.internal_file_path;
     info.global_seqno = f.assigned_seqno;
     info.table_properties = f.table_properties;
+    info.picked_level = f.picked_level;
     for (auto listener : immutable_db_options_.listeners) {
       listener->OnExternalFileIngested(this, info);
     }

--- a/db/external_sst_file_ingestion_job.cc
+++ b/db/external_sst_file_ingestion_job.cc
@@ -3,7 +3,6 @@
 //  COPYING file in the root directory) and Apache 2.0 License
 //  (found in the LICENSE.Apache file in the root directory).
 
-
 #include "db/external_sst_file_ingestion_job.h"
 
 #include <algorithm>
@@ -912,16 +911,19 @@ Status ExternalSstFileIngestionJob::AssignLevelAndSeqnoForIngestedFile(
     if (lvl > 0 && lvl < vstorage->base_level()) {
       continue;
     }
-    if (cfd_->RangeOverlapWithCompaction(
-            file_to_ingest->smallest_internal_key.user_key(),
-            file_to_ingest->largest_internal_key.user_key(), lvl)) {
-      // We must use L0 or any level higher than `lvl` to be able to overwrite
-      // the compaction output keys that we overlap with in this level, We also
-      // need to assign this file a seqno to overwrite the compaction output
-      // keys in level `lvl`
-      overlap_with_db = true;
-      break;
-    } else if (vstorage->NumLevelFiles(lvl) > 0) {
+    // if (cfd_->RangeOverlapWithCompaction(
+    //         file_to_ingest->smallest_internal_key.user_key(),
+    //         file_to_ingest->largest_internal_key.user_key(), lvl)) {
+    //   // We must use L0 or any level higher than `lvl` to be able to
+    //   overwrite
+    //   // the compaction output keys that we overlap with in this level, We
+    //   also
+    //   // need to assign this file a seqno to overwrite the compaction output
+    //   // keys in level `lvl`
+    //   overlap_with_db = true;
+    //   break;
+    // } else if (vstorage->NumLevelFiles(lvl) > 0) {
+    if (vstorage->NumLevelFiles(lvl) > 0) {
       bool overlap_with_level = false;
       status = sv->current->OverlapWithLevelIterator(
           ro, env_options_, file_to_ingest->smallest_internal_key.user_key(),


### PR DESCRIPTION
Reverting part of change made in https://github.com/facebook/rocksdb/pull/10988 that stops SSTs ingestion select deeper levels when find it conflicting with ongoing compactions. This change made massive ingestions (e.g. backfilling) more likely to be ingested into shallow levels especially level 0, and triggered stall.

Also raised this issue to the maintainer: https://github.com/facebook/rocksdb/issues/13091