### PR TITLE
Revert "Snapshot release triggered compaction without multiple tombstones"

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1030,8 +1030,6 @@ Note: The next release will be major release 7.0. See https://github.com/faceboo
 * BackupEngineOptions::sync (default true) now applies to restoring backups in addition to creating backups. This could slow down restores, but ensures they are fully persisted before returning OK. (Consider increasing max_background_operations to improve performance.)
 
 ## 6.23.0 (2021-07-16)
-### Behavior Changes
-* Obsolete keys in the bottommost level that were preserved for a snapshot will now be cleaned upon snapshot release in all cases. This form of compaction (snapshot release triggered compaction) previously had an artificial limitation that multiple tombstones needed to be present.
 ### Bug Fixes
 * Blob file checksums are now printed in hexadecimal format when using the `manifest_dump` `ldb` command.
 * `GetLiveFilesMetaData()` now populates the `temperature`, `oldest_ancester_time`, and `file_creation_time` fields of its `LiveFileMetaData` results when the information is available. Previously these fields always contained zero indicating unknown.
@@ -1056,6 +1054,7 @@ Note: The next release will be major release 7.0. See https://github.com/faceboo
 ### Behavior Changes
 * Added two additional tickers, MEMTABLE_PAYLOAD_BYTES_AT_FLUSH and MEMTABLE_GARBAGE_BYTES_AT_FLUSH. These stats can be used to estimate the ratio of "garbage" (outdated) bytes in the memtable that are discarded at flush time.
 * Added API comments clarifying safe usage of Disable/EnableManualCompaction and EventListener callbacks for compaction.
+
 ### Bug Fixes
 * fs_posix.cc GetFreeSpace() always report disk space available to root even when running as non-root.  Linux defaults often have disk mounts with 5 to 10 percent of total space reserved only for root.  Out of space could result for non-root users.
 * Subcompactions are now disabled when user-defined timestamps are used, since the subcompaction boundary picking logic is currently not timestamp-aware, which could lead to incorrect results when different subcompactions process keys that only differ by timestamp.

--- a/db/version_set.cc
+++ b/db/version_set.cc
@@ -4216,7 +4216,8 @@ void VersionStorageInfo::ComputeBottommostFilesMarkedForCompaction(
 
   for (auto& level_and_file : bottommost_files_) {
     if (!level_and_file.second->being_compacted &&
-        level_and_file.second->fd.largest_seqno != 0) {
+        level_and_file.second->fd.largest_seqno != 0 &&
+        level_and_file.second->num_deletions > 1) {
       // largest_seqno might be nonzero due to containing the final key in an
       // earlier compaction, whose seqnum we didn't zero out.
       if (level_and_file.second->fd.largest_seqno < oldest_snapshot_seqnum_) {

--- a/utilities/blob_db/blob_db_test.cc
+++ b/utilities/blob_db/blob_db_test.cc
@@ -570,6 +570,7 @@ TEST_F(BlobDBTest, EnableDisableCompressionGC) {
   Random rnd(301);
   BlobDBOptions bdb_options;
   bdb_options.min_blob_size = 0;
+  bdb_options.enable_garbage_collection = true;
   bdb_options.garbage_collection_cutoff = 1.0;
   bdb_options.disable_background_tasks = true;
   bdb_options.compression = kSnappyCompression;
@@ -597,11 +598,6 @@ TEST_F(BlobDBTest, EnableDisableCompressionGC) {
   blob_files = blob_db_impl()->TEST_GetBlobFiles();
   ASSERT_EQ(2, blob_files.size());
   ASSERT_EQ(kNoCompression, blob_files[1]->GetCompressionType());
-
-  // Enable GC. If we do it earlier the snapshot release triggered compaction
-  // may compact files and trigger GC before we can verify there are two files.
-  bdb_options.enable_garbage_collection = true;
-  Reopen(bdb_options);
 
   // Trigger compaction
   ASSERT_OK(blob_db_->CompactRange(CompactRangeOptions(), nullptr, nullptr));
@@ -641,6 +637,7 @@ TEST_F(BlobDBTest, ChangeCompressionGC) {
   Random rnd(301);
   BlobDBOptions bdb_options;
   bdb_options.min_blob_size = 0;
+  bdb_options.enable_garbage_collection = true;
   bdb_options.garbage_collection_cutoff = 1.0;
   bdb_options.disable_background_tasks = true;
   bdb_options.compression = kLZ4Compression;
@@ -669,11 +666,6 @@ TEST_F(BlobDBTest, ChangeCompressionGC) {
   blob_files = blob_db_impl()->TEST_GetBlobFiles();
   ASSERT_EQ(2, blob_files.size());
   ASSERT_EQ(kSnappyCompression, blob_files[1]->GetCompressionType());
-
-  // Enable GC. If we do it earlier the snapshot release triggered compaction
-  // may compact files and trigger GC before we can verify there are two files.
-  bdb_options.enable_garbage_collection = true;
-  Reopen(bdb_options);
 
   ASSERT_OK(blob_db_->CompactRange(CompactRangeOptions(), nullptr, nullptr));
   VerifyDB(data);


### PR DESCRIPTION
Revert "Revert " Revert "Snapshot release triggered compaction without multiple tombstones (#8357)" (#8410)" (#8438)"

We observed:
1. Performance regression
2. Compaction pattern change, especially during TiDB's add index test (using ingestions). We observed abnormal "compaction pending bytes", irregular write batching ("done by others" were significantly lower), flush, level 0 compaction were impacted, level 0 files accumulation (triggered write stall).

We also tried the new option introduced in https://github.com/facebook/rocksdb/pull/11701 for delaying such compactions, but it did not resolve the issue.

So, we are reverting the commit.
This reverts commit f89423a57a78e28de68c9a618a6e5f2f00ec5270.

Maintainer's node:
We need to cherry-pick this in future RocksDB upgrades, until new improvements are proposed in upstream.