### PR TITLE
Add enable_pipelined_commit as deprecated option

### DIFF
--- a/options/db_options.cc
+++ b/options/db_options.cc
@@ -327,6 +327,9 @@ static std::unordered_map<std::string, OptionTypeInfo>
          {offsetof(struct ImmutableDBOptions, enable_pipelined_write),
           OptionType::kBoolean, OptionVerificationType::kNormal,
           OptionTypeFlags::kNone}},
+        {"enable_pipelined_commit",
+         {0, OptionType::kBoolean, OptionVerificationType::kDeprecated,
+          OptionTypeFlags::kNone}},
         {"enable_multi_batch_write",
          {offsetof(struct ImmutableDBOptions, enable_multi_batch_write),
           OptionType::kBoolean, OptionVerificationType::kNormal,
@@ -922,8 +925,7 @@ void ImmutableDBOptions::Dump(Logger* log) const {
   ROCKS_LOG_HEADER(log, "            Options.wal_compression: %d",
                    wal_compression);
   ROCKS_LOG_HEADER(log, "            Options.atomic_flush: %d", atomic_flush);
-  ROCKS_LOG_HEADER(log,
-                   "            Options.avoid_unnecessary_blocking_io: %d",
+  ROCKS_LOG_HEADER(log, "            Options.avoid_unnecessary_blocking_io: %d",
                    avoid_unnecessary_blocking_io);
   ROCKS_LOG_HEADER(log, "                Options.persist_stats_to_disk: %u",
                    persist_stats_to_disk);
@@ -1060,14 +1062,13 @@ void MutableDBOptions::Dump(Logger* log) const {
   ROCKS_LOG_HEADER(log,
                    "                     Options.wal_bytes_per_sync: %" PRIu64,
                    wal_bytes_per_sync);
-  ROCKS_LOG_HEADER(log,
-                   "                  Options.strict_bytes_per_sync: %d",
+  ROCKS_LOG_HEADER(log, "                  Options.strict_bytes_per_sync: %d",
                    strict_bytes_per_sync);
   ROCKS_LOG_HEADER(log,
                    "      Options.compaction_readahead_size: %" ROCKSDB_PRIszt,
                    compaction_readahead_size);
   ROCKS_LOG_HEADER(log, "                 Options.max_background_flushes: %d",
-                          max_background_flushes);
+                   max_background_flushes);
   ROCKS_LOG_HEADER(log, "Options.daily_offpeak_time_utc: %s",
                    daily_offpeak_time_utc.c_str());
 }


### PR DESCRIPTION
`enable_pipelined_commit` was introduced by TiKV before, but got renamed to `enable_multi_batch_write` later. However, there are some versions of TiKV still running with `enable_pipelined_commit` (either false or true) persisted in `OPTIONS-xxxx` file under RocksDB directory, when upgrading these TiKVs, they will panic because of "load_latest_options" who reads the `OPTIONS-xxxx` does not recognize the option.

Now, add this option as a deprecated option, so that, it won't cause a `InvalidArgument` panic, nor will it be serialized in `OPTIONS-xxxx` files anymore.