### PR TITLE
rate-limiter: fix clock skew if enabling auto-tuned.

### DIFF
--- a/utilities/rate_limiters/write_amp_based_rate_limiter.cc
+++ b/utilities/rate_limiters/write_amp_based_rate_limiter.cc
@@ -430,7 +430,7 @@ Status WriteAmpBasedRateLimiter::Tune() {
   }
   new_bytes_per_sec += padding + new_bytes_per_sec * percent_delta_ / 100;
   new_bytes_per_sec =
-      std::max(kMinBytesPerSec,
+      std::max(kMinBytesPerSec * 10, /* 100 MiB/s */
                std::min(new_bytes_per_sec,
                         max_bytes_per_sec_.load(std::memory_order_relaxed) -
                             highpri_bytes_sampler_.GetRecentValue()));

--- a/utilities/rate_limiters/write_amp_based_rate_limiter.cc
+++ b/utilities/rate_limiters/write_amp_based_rate_limiter.cc
@@ -374,13 +374,13 @@ Status WriteAmpBasedRateLimiter::Tune() {
   std::chrono::microseconds prev_tuned_time = tuned_time_;
   tuned_time_ = std::chrono::microseconds(NowMicrosMonotonic(env_));
   auto duration = tuned_time_ - prev_tuned_time;
-  // Use previous rate limiter if duration is invalid or exceeds max limit:
+  // Use max rate limiter if duration is invalid or exceeds max limit:
   // (1) negative durations indicate clock skew
   // (2) durations > max_tune_tick_duration_limit are likely due to system
   //     issues or clock skew issues.
   if (duration < std::chrono::microseconds::zero() ||
       duration > max_tune_tick_duration_limit) {
-    SetActualBytesPerSecond(prev_bytes_per_sec);
+    SetActualBytesPerSecond(max_bytes_per_sec_.load(std::memory_order_relaxed));
     return Status::Aborted();
   }
   auto duration_ms =

--- a/utilities/rate_limiters/write_amp_based_rate_limiter.cc
+++ b/utilities/rate_limiters/write_amp_based_rate_limiter.cc
@@ -195,7 +195,7 @@ void WriteAmpBasedRateLimiter::Request(int64_t bytes, const Env::IOPriority pri,
     if (leader_ == nullptr && IsFrontOfOneQueue(&r)) {
       leader_ = &r;
       int64_t delta = next_refill_us_ - NowMicrosMonotonic(env_);
-      delta = delta > 0 ? delta : 0;
+      delta = delta > 0 ? std::min(delta, refill_period_us_) : 0;
       if (delta == 0) {
         timedout = true;
       } else {
@@ -368,6 +368,7 @@ Status WriteAmpBasedRateLimiter::Tune() {
   auto duration = tuned_time_ - prev_tuned_time;
   // To avoid the duration is affected by clock-skew problems, set a compatible
   // limitation to it.
+  // TODO: if the duration is too long, skip the tune tick.
   auto duration_limit = std::chrono::microseconds(1000 * 1000 * secs_per_tune_);
   auto max_duration_limit = std::chrono::microseconds(
       1000 * 1500 * secs_per_tune_);  // max_limitation == 1.5 * base

--- a/utilities/rate_limiters/write_amp_based_rate_limiter.cc
+++ b/utilities/rate_limiters/write_amp_based_rate_limiter.cc
@@ -369,21 +369,22 @@ Status WriteAmpBasedRateLimiter::Tune() {
       std::chrono::microseconds(secs_per_tune_ * 1000 * 1000) * 7 /
       4;  // 1.75x multiplier
 
+  int64_t prev_bytes_per_sec = GetBytesPerSecond();
+
   std::chrono::microseconds prev_tuned_time = tuned_time_;
   tuned_time_ = std::chrono::microseconds(NowMicrosMonotonic(env_));
   auto duration = tuned_time_ - prev_tuned_time;
-  // Skip tuning if duration is invalid or exceeds max limit:
+  // Use previous rate limiter if duration is invalid or exceeds max limit:
   // (1) negative durations indicate clock skew
   // (2) durations > max_tune_tick_duration_limit are likely due to system
   //     issues or clock skew issues.
   if (duration < std::chrono::microseconds::zero() ||
       duration > max_tune_tick_duration_limit) {
+    SetActualBytesPerSecond(prev_bytes_per_sec);
     return Status::Aborted();
   }
   auto duration_ms =
       std::chrono::duration_cast<std::chrono::milliseconds>(duration).count();
-
-  int64_t prev_bytes_per_sec = GetBytesPerSecond();
 
   // This function can be called less frequent than we anticipate when
   // compaction rate is low. Loop through the actual time slice to correct

--- a/utilities/rate_limiters/write_amp_based_rate_limiter.cc
+++ b/utilities/rate_limiters/write_amp_based_rate_limiter.cc
@@ -369,8 +369,6 @@ Status WriteAmpBasedRateLimiter::Tune() {
       std::chrono::microseconds(secs_per_tune_ * 1000 * 1000) * 7 /
       4;  // 1.75x multiplier
 
-  int64_t prev_bytes_per_sec = GetBytesPerSecond();
-
   std::chrono::microseconds prev_tuned_time = tuned_time_;
   tuned_time_ = std::chrono::microseconds(NowMicrosMonotonic(env_));
   auto duration = tuned_time_ - prev_tuned_time;
@@ -386,6 +384,7 @@ Status WriteAmpBasedRateLimiter::Tune() {
   auto duration_ms =
       std::chrono::duration_cast<std::chrono::milliseconds>(duration).count();
 
+  int64_t prev_bytes_per_sec = GetBytesPerSecond();
   // This function can be called less frequent than we anticipate when
   // compaction rate is low. Loop through the actual time slice to correct
   // the estimation.

--- a/utilities/rate_limiters/write_amp_based_rate_limiter.cc
+++ b/utilities/rate_limiters/write_amp_based_rate_limiter.cc
@@ -121,7 +121,7 @@ void WriteAmpBasedRateLimiter::SetAutoTuned(bool auto_tuned) {
 
 void WriteAmpBasedRateLimiter::SetActualBytesPerSecond(
     int64_t bytes_per_second) {
-  rate_bytes_per_sec_ = bytes_per_second;
+  rate_bytes_per_sec_ = bytes_per_second; /* Init: 10GiB*/
   refill_bytes_per_period_.store(
       CalculateRefillBytesPerPeriod(bytes_per_second),
       std::memory_order_relaxed);
@@ -334,13 +334,16 @@ void WriteAmpBasedRateLimiter::Refill() {
 
 int64_t WriteAmpBasedRateLimiter::CalculateRefillBytesPerPeriod(
     int64_t rate_bytes_per_sec) {
+  // Max limit: 9223372036854775807 / 100_000 = 922337203685477.6
   if (std::numeric_limits<int64_t>::max() / rate_bytes_per_sec <
       refill_period_us_) {
     // Avoid unexpected result in the overflow case. The result now is still
     // inaccurate but is a number that is large enough.
-    return std::numeric_limits<int64_t>::max() / 1000000;
+    return std::numeric_limits<int64_t>::max() /
+           1000000; /* == 9223372036854LL*/
   } else {
-    return std::max(kMinRefillBytesPerPeriod,
+    // Init: 10 GiB/s / 10 = 1GiB
+    return std::max(kMinRefillBytesPerPeriod * 1000 * 1000 /* 100 MiB */,
                     rate_bytes_per_sec * refill_period_us_ / 1000000);
   }
 }
@@ -451,8 +454,8 @@ void WriteAmpBasedRateLimiter::PaceUp(bool critical) {
 }
 
 RateLimiter* NewWriteAmpBasedRateLimiter(
-    int64_t rate_bytes_per_sec, int64_t refill_period_us /* = 100 * 1000 */,
-    int32_t fairness /* = 10 */,
+    int64_t rate_bytes_per_sec /* 10GiB */,
+    int64_t refill_period_us /* = 100 * 1000 */, int32_t fairness /* = 10 */,
     RateLimiter::Mode mode /* = RateLimiter::Mode::kWritesOnly */,
     bool auto_tuned /* = false */, int tune_per_sec /* = 1 */,
     size_t smooth_window_size /* = 300 */,

--- a/utilities/rate_limiters/write_amp_based_rate_limiter.cc
+++ b/utilities/rate_limiters/write_amp_based_rate_limiter.cc
@@ -366,9 +366,10 @@ Status WriteAmpBasedRateLimiter::Tune() {
   // To avoid the duration is affected by clock-skew problems, set a compatible
   // limitation to it.
   auto duration_limit = std::chrono::microseconds(1000 * 1000 * secs_per_tune_);
-  if (duration < std::chrono::microseconds::zero() ||
-      duration > duration_limit) {
+  if (duration < std::chrono::microseconds::zero()) {
     duration = duration_limit;
+  } else if (duration > duration_limit) {
+    duration = duration_limit * 5;
   }
   auto duration_ms =
       std::chrono::duration_cast<std::chrono::milliseconds>(duration).count();

--- a/utilities/rate_limiters/write_amp_based_rate_limiter.cc
+++ b/utilities/rate_limiters/write_amp_based_rate_limiter.cc
@@ -369,20 +369,22 @@ Status WriteAmpBasedRateLimiter::Tune() {
       std::chrono::microseconds(secs_per_tune_ * 1000 * 1000) * 7 /
       4;  // 1.75x multiplier
 
-  std::chrono::microseconds prev_tuned_time = tuned_time_;
+  const std::chrono::microseconds prev_tuned_time = tuned_time_;
   tuned_time_ = std::chrono::microseconds(NowMicrosMonotonic(env_));
-  auto duration = tuned_time_ - prev_tuned_time;
-  // Use max rate limiter if duration is invalid or exceeds max limit:
-  // (1) negative durations indicate clock skew
-  // (2) durations > max_tune_tick_duration_limit are likely due to system
-  //     issues or clock skew issues.
-  if (duration < std::chrono::microseconds::zero() ||
-      duration > max_tune_tick_duration_limit) {
+  // Validate tuning interval to detect system anomalies:
+  // (1) tuned_time_ < prev_tuned_time: Clock moved backwards (clock skew)
+  // (2) Interval > max_tune_tick_duration_limit: System stall or severe clock
+  // skew
+  if (tuned_time_ <= prev_tuned_time ||
+      tuned_time_ >= prev_tuned_time + max_tune_tick_duration_limit) {
+    // Fall back to max rate limiter for safety if duration is invalid or
+    // exceeds max limit.
     SetActualBytesPerSecond(max_bytes_per_sec_.load(std::memory_order_relaxed));
     return Status::Aborted();
   }
-  auto duration_ms =
-      std::chrono::duration_cast<std::chrono::milliseconds>(duration).count();
+  auto duration_ms = std::chrono::duration_cast<std::chrono::milliseconds>(
+                         tuned_time_ - prev_tuned_time)
+                         .count();
 
   int64_t prev_bytes_per_sec = GetBytesPerSecond();
   // This function can be called less frequent than we anticipate when

--- a/utilities/rate_limiters/write_amp_based_rate_limiter.cc
+++ b/utilities/rate_limiters/write_amp_based_rate_limiter.cc
@@ -121,7 +121,7 @@ void WriteAmpBasedRateLimiter::SetAutoTuned(bool auto_tuned) {
 
 void WriteAmpBasedRateLimiter::SetActualBytesPerSecond(
     int64_t bytes_per_second) {
-  rate_bytes_per_sec_ = bytes_per_second; /* Init: 10GiB*/
+  rate_bytes_per_sec_ = bytes_per_second;
   refill_bytes_per_period_.store(
       CalculateRefillBytesPerPeriod(bytes_per_second),
       std::memory_order_relaxed);
@@ -195,6 +195,10 @@ void WriteAmpBasedRateLimiter::Request(int64_t bytes, const Env::IOPriority pri,
     if (leader_ == nullptr && IsFrontOfOneQueue(&r)) {
       leader_ = &r;
       int64_t delta = next_refill_us_ - NowMicrosMonotonic(env_);
+      // Clamp delta between 0 and refill_period_us_:
+      // (1) set negative values to 0
+      // (2) cap maximum wait time to refill_period_us_ to prevent excessive
+      //     delays that could occur due to clock skew.
       delta = delta > 0 ? std::min(delta, refill_period_us_) : 0;
       if (delta == 0) {
         timedout = true;
@@ -334,16 +338,13 @@ void WriteAmpBasedRateLimiter::Refill() {
 
 int64_t WriteAmpBasedRateLimiter::CalculateRefillBytesPerPeriod(
     int64_t rate_bytes_per_sec) {
-  // Max limit: 9223372036854775807 / 100_000 = 922337203685477.6
   if (std::numeric_limits<int64_t>::max() / rate_bytes_per_sec <
       refill_period_us_) {
     // Avoid unexpected result in the overflow case. The result now is still
     // inaccurate but is a number that is large enough.
-    return std::numeric_limits<int64_t>::max() /
-           1000000; /* == 9223372036854LL*/
+    return std::numeric_limits<int64_t>::max() / 1000000;
   } else {
-    // Init: 10 GiB/s / 10 = 1GiB
-    return std::max(kMinRefillBytesPerPeriod * 1000 * 1000 /* 100 MiB */,
+    return std::max(kMinRefillBytesPerPeriod,
                     rate_bytes_per_sec * refill_period_us_ / 1000000);
   }
 }
@@ -362,20 +363,22 @@ Status WriteAmpBasedRateLimiter::Tune() {
   // lower bound for write amplification estimation
   const int kRatioLower = 10;
   const int kPercentDeltaMax = 6;
+  const auto millis_per_tune = 1000 * secs_per_tune_;
+  // Define the max limit of tick duration limits to handle clock skew.
+  const auto max_tune_tick_duration_limit =
+      std::chrono::microseconds(secs_per_tune_ * 1000 * 1000) * 7 /
+      4;  // 1.75x multiplier
 
   std::chrono::microseconds prev_tuned_time = tuned_time_;
   tuned_time_ = std::chrono::microseconds(NowMicrosMonotonic(env_));
   auto duration = tuned_time_ - prev_tuned_time;
-  // To avoid the duration is affected by clock-skew problems, set a compatible
-  // limitation to it.
-  // TODO: if the duration is too long, skip the tune tick.
-  auto duration_limit = std::chrono::microseconds(1000 * 1000 * secs_per_tune_);
-  auto max_duration_limit = std::chrono::microseconds(
-      1000 * 1500 * secs_per_tune_);  // max_limitation == 1.5 * base
-  if (duration < std::chrono::microseconds::zero()) {
-    duration = duration_limit;
-  } else if (duration > max_duration_limit) {
-    duration = max_duration_limit;
+  // Skip tuning if duration is invalid or exceeds max limit:
+  // (1) negative durations indicate clock skew
+  // (2) durations > max_tune_tick_duration_limit are likely due to system
+  //     issues or clock skew issues.
+  if (duration < std::chrono::microseconds::zero() ||
+      duration > max_tune_tick_duration_limit) {
+    return Status::Aborted();
   }
   auto duration_ms =
       std::chrono::duration_cast<std::chrono::milliseconds>(duration).count();
@@ -385,8 +388,8 @@ Status WriteAmpBasedRateLimiter::Tune() {
   // This function can be called less frequent than we anticipate when
   // compaction rate is low. Loop through the actual time slice to correct
   // the estimation.
-  auto millis_per_tune = 1000 * secs_per_tune_;
-  for (uint32_t i = 0; i < duration_ms / millis_per_tune; i++) {
+  auto sampling_count = duration_ms / millis_per_tune;
+  for (uint32_t i = 0; i < sampling_count; i++) {
     bytes_sampler_.AddSample(duration_bytes_through_ * 1000 / duration_ms);
     highpri_bytes_sampler_.AddSample(duration_highpri_bytes_through_ * 1000 /
                                      duration_ms);
@@ -431,7 +434,7 @@ Status WriteAmpBasedRateLimiter::Tune() {
   }
   new_bytes_per_sec += padding + new_bytes_per_sec * percent_delta_ / 100;
   new_bytes_per_sec =
-      std::max(kMinBytesPerSec * 10, /* 100 MiB/s */
+      std::max(kMinBytesPerSec,
                std::min(new_bytes_per_sec,
                         max_bytes_per_sec_.load(std::memory_order_relaxed) -
                             highpri_bytes_sampler_.GetRecentValue()));
@@ -455,7 +458,7 @@ void WriteAmpBasedRateLimiter::PaceUp(bool critical) {
 }
 
 RateLimiter* NewWriteAmpBasedRateLimiter(
-    int64_t rate_bytes_per_sec /* 10GiB */,
+    int64_t rate_bytes_per_sec /* = 10GiB */,
     int64_t refill_period_us /* = 100 * 1000 */, int32_t fairness /* = 10 */,
     RateLimiter::Mode mode /* = RateLimiter::Mode::kWritesOnly */,
     bool auto_tuned /* = false */, int tune_per_sec /* = 1 */,

--- a/utilities/rate_limiters/write_amp_based_rate_limiter.cc
+++ b/utilities/rate_limiters/write_amp_based_rate_limiter.cc
@@ -363,6 +363,13 @@ Status WriteAmpBasedRateLimiter::Tune() {
   std::chrono::microseconds prev_tuned_time = tuned_time_;
   tuned_time_ = std::chrono::microseconds(NowMicrosMonotonic(env_));
   auto duration = tuned_time_ - prev_tuned_time;
+  // To avoid the duration is affected by clock-skew problems, set a compatible
+  // limitation to it.
+  auto duration_limit = std::chrono::microseconds(1000 * 1000 * secs_per_tune_);
+  if (duration < std::chrono::microseconds::zero() ||
+      duration > duration_limit) {
+    duration = duration_limit;
+  }
   auto duration_ms =
       std::chrono::duration_cast<std::chrono::milliseconds>(duration).count();
 

--- a/utilities/rate_limiters/write_amp_based_rate_limiter.cc
+++ b/utilities/rate_limiters/write_amp_based_rate_limiter.cc
@@ -366,10 +366,12 @@ Status WriteAmpBasedRateLimiter::Tune() {
   // To avoid the duration is affected by clock-skew problems, set a compatible
   // limitation to it.
   auto duration_limit = std::chrono::microseconds(1000 * 1000 * secs_per_tune_);
+  auto max_duration_limit = std::chrono::microseconds(
+      1000 * 1500 * secs_per_tune_);  // max_limitation == 1.5 * base
   if (duration < std::chrono::microseconds::zero()) {
     duration = duration_limit;
-  } else if (duration > duration_limit) {
-    duration = duration_limit * 3;  // max_limitation == 3 * base
+  } else if (duration > max_duration_limit) {
+    duration = max_duration_limit;
   }
   auto duration_ms =
       std::chrono::duration_cast<std::chrono::milliseconds>(duration).count();

--- a/utilities/rate_limiters/write_amp_based_rate_limiter.cc
+++ b/utilities/rate_limiters/write_amp_based_rate_limiter.cc
@@ -369,7 +369,7 @@ Status WriteAmpBasedRateLimiter::Tune() {
   if (duration < std::chrono::microseconds::zero()) {
     duration = duration_limit;
   } else if (duration > duration_limit) {
-    duration = duration_limit * 5;
+    duration = duration_limit * 3;  // max_limitation == 3 * base
   }
   auto duration_ms =
       std::chrono::duration_cast<std::chrono::milliseconds>(duration).count();

--- a/utilities/rate_limiters/write_amp_based_rate_limiter_test.cc
+++ b/utilities/rate_limiters/write_amp_based_rate_limiter_test.cc
@@ -80,11 +80,12 @@ TEST_F(WriteAmpBasedRateLimiterTest, AutoTune) {
                   RateLimiter::OpType::kWrite);
   ASSERT_EQ(10485760, limiter.GetBytesPerSecond());
   // If there exists clock skew issues, the next Tune()
-  // should be skpped.
+  // should be skipped and use the max_rate_bytes_per_sec
+  // as the next limit.
   thread_env->SleepForMicroseconds(2000 * 1000);
   limiter.Request(1000 /* bytes */, Env::IO_LOW, nullptr /* stats */,
                   RateLimiter::OpType::kWrite);
-  ASSERT_EQ(10485760, limiter.GetBytesPerSecond());
+  ASSERT_EQ(10000, limiter.GetBytesPerSecond());
   // TODO: add more logic for auto-tune
 }
 

--- a/utilities/rate_limiters/write_amp_based_rate_limiter_test.cc
+++ b/utilities/rate_limiters/write_amp_based_rate_limiter_test.cc
@@ -86,6 +86,13 @@ TEST_F(WriteAmpBasedRateLimiterTest, AutoTune) {
   limiter.Request(1000 /* bytes */, Env::IO_LOW, nullptr /* stats */,
                   RateLimiter::OpType::kWrite);
   ASSERT_EQ(10000, limiter.GetBytesPerSecond());
+  // After recovering, the auto-tune works normally.
+  for (auto i = 1; i <= 3; i++) {
+    thread_env->SleepForMicroseconds(1000 * 1000);
+    limiter.Request(1000 /* bytes */, Env::IO_LOW, nullptr /* stats */,
+                    RateLimiter::OpType::kWrite);
+    ASSERT_EQ(10485760, limiter.GetBytesPerSecond());
+  }
   // TODO: add more logic for auto-tune
 }
 

--- a/utilities/rate_limiters/write_amp_based_rate_limiter_test.cc
+++ b/utilities/rate_limiters/write_amp_based_rate_limiter_test.cc
@@ -79,6 +79,12 @@ TEST_F(WriteAmpBasedRateLimiterTest, AutoTune) {
   limiter.Request(1000 /* bytes */, Env::IO_LOW, nullptr /* stats */,
                   RateLimiter::OpType::kWrite);
   ASSERT_EQ(10485760, limiter.GetBytesPerSecond());
+  // If there exists clock skew issues, the next Tune()
+  // should be skpped.
+  thread_env->SleepForMicroseconds(2000 * 1000);
+  limiter.Request(1000 /* bytes */, Env::IO_LOW, nullptr /* stats */,
+                  RateLimiter::OpType::kWrite);
+  ASSERT_EQ(10485760, limiter.GetBytesPerSecond());
   // TODO: add more logic for auto-tune
 }
 


### PR DESCRIPTION
## Issue
Close https://github.com/tikv/tikv/issues/17995
Currently, in TIKV, there are two issues encountered when enabling auto-tuning on WriteAmpBasedRateLimiter in the presence of clock-skew problems:
- The `Request()` operation may experience excessive waiting if the time offset is too large, causing pending compactions to hang unexpectedly.
- The `Tune()` process uses an excessively small value for updated bytes to calculate the next `rate_bytes_per_sec_`. This results in the next `Request()` being starved, as `rate_bytes_per_sec_` becomes significantly smaller than the pending requested bytes.

![image](https://github.com/user-attachments/assets/22d20177-4846-4e24-b1fd-88b8957cf362)


## Introduction to this PR
To address these two issues in the presence of clock-skew problems, this PR introduces the following changes:
- Clamps the wait-time limit between 0 and `refill_period_us_` to prevent excessively long waits.
- To preserve the current tuning algorithm, the maximum rate limiter is used if it encounters clock-skew issues, ensuring that `Request()` operations do not starve.

After applying this PR, the testing results as followings shows proves that it can solve the clock-skew problem as expected:
![image](https://github.com/user-attachments/assets/40ede9a6-ba94-48dd-9eb7-fa8c9d06a6c9)
