### PR TITLE
RocksDB should expose key type

### DIFF
--- a/db/db_iter.cc
+++ b/db/db_iter.cc
@@ -417,15 +417,17 @@ bool DBIter::FindNextUserEntryInternal(bool skipping_saved_key,
               if (!SetValueAndColumnsFromEntity(iter_.value())) {
                 return false;
               }
-            } else {
+            } else if (ikey_.type == kTypeTitanBlobIndex) {
               // Titan blob index should be handled as plain value by RocksDB,
               // should not go through SetBlobValueIfNeeded().
               // Even though Titan bypasses the real blob index evaluation
               // by propagating expose_blob_index_.option. This is to prevent
               // TiKV, that directly uses RocksDB, from trying to evaluate the
               // orphaned blob indices after Titan is disabled.
-              assert(ikey_.type == kTypeValue ||
-                     ikey_.type == kTypeTitanBlobIndex);
+              is_blob_ = true;
+              SetValueAndColumnsFromPlain(iter_.value());
+            } else {
+              assert(ikey_.type == kTypeValue);
               SetValueAndColumnsFromPlain(iter_.value());
             }
 


### PR DESCRIPTION
Follow up of #412

#412 made RocksDB treats Titan blob index as plain value, however, Titan also rely on RocksDB's internal key type to identify whether the value is blob index or plain value. 
See Titan's code [here](https://github.com/v01dstar/titan/blob/a336e598a8405b430360befcacefd3d5eac73ec3/src/db_iter.h#L95)
So, this PR sets iter.is_blob_ when meeting a Titan blob index.

Maintenance:
Merge this with https://github.com/tikv/rocksdb/pull/388 in the future maintenance