### PR TITLE
compaction: add a new option 'check_range_overlap_on_bottom_level' for manual compact

### DIFF
--- a/db/db_impl/db_impl_compaction_flush.cc
+++ b/db/db_impl/db_impl_compaction_flush.cc
@@ -1234,7 +1234,10 @@ Status DBImpl::CompactRangeInternal(const CompactRangeOptions& options,
             check_overlap_within_file = false;
           }
         }
-        if (!check_overlap_within_file) {
+        if (!check_overlap_within_file ||
+            (!overlap && options.bottom_level_check_range_overlap &&
+             level ==
+                 current_version->storage_info()->num_non_empty_levels() - 1)) {
           overlap = current_version->storage_info()->OverlapInLevel(level,
                                                                     begin, end);
         }

--- a/db/db_impl/db_impl_compaction_flush.cc
+++ b/db/db_impl/db_impl_compaction_flush.cc
@@ -1234,6 +1234,10 @@ Status DBImpl::CompactRangeInternal(const CompactRangeOptions& options,
             check_overlap_within_file = false;
           }
         }
+        // `bottom_level_check_range_overlap` set to true means we check SST
+        // range overlap instead of real kv overlap to ensure that Manual
+        // Compact can be trigger on the overlapped SST files, so the SST files
+        // with big range can be split by the CompactionPartitioner.
         if (!check_overlap_within_file ||
             (!overlap && options.bottom_level_check_range_overlap &&
              level ==

--- a/db/db_impl/db_impl_compaction_flush.cc
+++ b/db/db_impl/db_impl_compaction_flush.cc
@@ -1234,12 +1234,12 @@ Status DBImpl::CompactRangeInternal(const CompactRangeOptions& options,
             check_overlap_within_file = false;
           }
         }
-        // `check_range_overlap_at_bottom_level` set to true means we check SST
+        // `check_range_overlap_on_bottom_level` set to true means we check SST
         // range overlap instead of real kv overlap to ensure that Manual
         // Compact can be trigger on the overlapped SST files, so the SST files
         // with big range can be split by the CompactionPartitioner.
         if (!check_overlap_within_file ||
-            (!overlap && options.check_range_overlap_at_bottom_level &&
+            (!overlap && options.check_range_overlap_on_bottom_level &&
              level ==
                  current_version->storage_info()->num_non_empty_levels() - 1)) {
           overlap = current_version->storage_info()->OverlapInLevel(level,

--- a/db/db_impl/db_impl_compaction_flush.cc
+++ b/db/db_impl/db_impl_compaction_flush.cc
@@ -1234,12 +1234,12 @@ Status DBImpl::CompactRangeInternal(const CompactRangeOptions& options,
             check_overlap_within_file = false;
           }
         }
-        // `bottom_level_check_range_overlap` set to true means we check SST
+        // `check_range_overlap_at_bottom_level` set to true means we check SST
         // range overlap instead of real kv overlap to ensure that Manual
         // Compact can be trigger on the overlapped SST files, so the SST files
         // with big range can be split by the CompactionPartitioner.
         if (!check_overlap_within_file ||
-            (!overlap && options.bottom_level_check_range_overlap &&
+            (!overlap && options.check_range_overlap_at_bottom_level &&
              level ==
                  current_version->storage_info()->num_non_empty_levels() - 1)) {
           overlap = current_version->storage_info()->OverlapInLevel(level,

--- a/db/external_sst_file_ingestion_job.cc
+++ b/db/external_sst_file_ingestion_job.cc
@@ -925,6 +925,9 @@ Status ExternalSstFileIngestionJob::AssignLevelAndSeqnoForIngestedFile(
         // the keys that we overlap with in this level, We also need to assign
         // this file a seqno to overwrite the existing keys in level `lvl`
         overlap_with_db = true;
+        ROCKS_LOG_INFO(db_options_.info_log,
+                       "Ingest file overlap with level %d, file: %s", lvl,
+                       file_to_ingest->internal_file_path.c_str());
         break;
       }
 
@@ -1110,6 +1113,10 @@ bool ExternalSstFileIngestionJob::IngestedFileFitInLevel(
                                &file_largest_user_key)) {
     // File overlap with another files in this level, we cannot
     // add it to this level
+    ROCKS_LOG_INFO(
+        db_options_.info_log,
+        "Ingest file overlap with level file range, level %d, ingset_file: %s",
+        level, file_to_ingest->internal_file_path.c_str());
     return false;
   }
 
@@ -1117,6 +1124,9 @@ bool ExternalSstFileIngestionJob::IngestedFileFitInLevel(
                                        file_largest_user_key, level)) {
     // File overlap with a running compaction output that will be stored
     // in this level, we cannot add this file to this level
+    ROCKS_LOG_INFO(db_options_.info_log,
+                   "Ingest file overlap with compaction in level %d, file: %s",
+                   level, file_to_ingest->internal_file_path.c_str());
     return false;
   }
 

--- a/include/rocksdb/options.h
+++ b/include/rocksdb/options.h
@@ -2020,6 +2020,11 @@ struct CompactRangeOptions {
   // user-provided setting. This enables customers to selectively override the
   // age cutoff.
   double blob_garbage_collection_age_cutoff = -1;
+
+  // If set to true, it will check file range overlap instead of keys overlap
+  // for the bottom level. This is used in manual compact for SST ingestion
+  // scenario.
+  bool bottom_level_check_range_overlap = false;
 };
 
 // IngestExternalFileOptions is used by IngestExternalFile()

--- a/include/rocksdb/options.h
+++ b/include/rocksdb/options.h
@@ -2024,7 +2024,7 @@ struct CompactRangeOptions {
   // If set to true, it will check file range overlap instead of keys overlap
   // for the bottom level. This is used in manual compact for SST ingestion
   // scenario.
-  bool check_range_overlap_at_bottom_level = false;
+  bool check_range_overlap_on_bottom_level = false;
 };
 
 // IngestExternalFileOptions is used by IngestExternalFile()

--- a/include/rocksdb/options.h
+++ b/include/rocksdb/options.h
@@ -2024,7 +2024,7 @@ struct CompactRangeOptions {
   // If set to true, it will check file range overlap instead of keys overlap
   // for the bottom level. This is used in manual compact for SST ingestion
   // scenario.
-  bool bottom_level_check_range_overlap = false;
+  bool check_range_overlap_at_bottom_level = false;
 };
 
 // IngestExternalFileOptions is used by IngestExternalFile()


### PR DESCRIPTION
- The new option `bottom_level_check_range_overlap` is used for manual compact to ensure the SST file in the bottom level with a huge range can be force partitioned with manual compaction.
- Also add a few log for the SST ingest level selection to make it easier to investigate unexpected SST ingestion level.