### PR TITLE
restore `ldb manifest_dump --sst_file_number` support

### DIFF
--- a/db/version_edit.cc
+++ b/db/version_edit.cc
@@ -59,6 +59,28 @@ Status FileMetaData::UpdateBoundaries(const Slice& key, const Slice& value,
   return Status::OK();
 }
 
+std::string FileMetaData::DebugString(bool hex) const {
+  std::string result;
+  AppendNumberTo(&result, fd.GetNumber());
+  result.push_back(':');
+  AppendNumberTo(&result, fd.GetFileSize());
+  result.append("[");
+  AppendNumberTo(&result, fd.smallest_seqno);
+  result.append(" .. ");
+  AppendNumberTo(&result, fd.largest_seqno);
+  result.append("]");
+  result.append("[");
+  result.append(smallest.DebugString(hex));
+  result.append(" .. ");
+  result.append(largest.DebugString(hex));
+  result.append("]");
+  if (oldest_blob_file_number != kInvalidBlobFileNumber) {
+    result.append(" blob_file:");
+    AppendNumberTo(&result, oldest_blob_file_number);
+  }
+  return result;
+}
+
 void VersionEdit::Clear() {
   max_level_ = 0;
   db_id_.clear();

--- a/db/version_edit.h
+++ b/db/version_edit.h
@@ -333,6 +333,8 @@ struct FileMetaData {
     return kUnknownFileCreationTime;
   }
 
+  std::string DebugString(bool hex) const;
+
   // WARNING: manual update to this function is needed
   // whenever a new string property is added to FileMetaData
   // to reduce approximation error.

--- a/db/version_edit_handler.cc
+++ b/db/version_edit_handler.cc
@@ -1055,34 +1055,74 @@ void DumpManifestHandler::CheckIterationResult(const log::Reader& reader,
     return;
   }
   assert(cf_to_cmp_names_);
+  bool found = false;
   for (auto* cfd : *(version_set_->column_family_set_)) {
-    fprintf(stdout,
-            "--------------- Column family \"%s\"  (ID %" PRIu32
-            ") --------------\n",
-            cfd->GetName().c_str(), cfd->GetID());
-    fprintf(stdout, "log number: %" PRIu64 "\n", cfd->GetLogNumber());
-    auto it = cf_to_cmp_names_->find(cfd->GetID());
-    if (it != cf_to_cmp_names_->end()) {
-      fprintf(stdout,
-              "comparator: <%s>, but the comparator object is not available.\n",
-              it->second.c_str());
-    } else {
-      fprintf(stdout, "comparator: %s\n", cfd->user_comparator()->Name());
+    if (cfd->IsDropped()) {
+      continue;
     }
     assert(cfd->current());
+    if (sst_file_number_ == 0) {
+      fprintf(stdout,
+              "--------------- Column family \"%s\"  (ID %" PRIu32
+              ") --------------\n",
+              cfd->GetName().c_str(), cfd->GetID());
+      fprintf(stdout, "log number: %" PRIu64 "\n", cfd->GetLogNumber());
+      auto it = cf_to_cmp_names_->find(cfd->GetID());
+      if (it != cf_to_cmp_names_->end()) {
+        fprintf(
+            stdout,
+            "comparator: <%s>, but the comparator object is not available.\n",
+            it->second.c_str());
+      } else {
+        fprintf(stdout, "comparator: %s\n", cfd->user_comparator()->Name());
+      }
 
-    // Print out DebugStrings. Can include non-terminating null characters.
-    fwrite(cfd->current()->DebugString(hex_).data(), sizeof(char),
-           cfd->current()->DebugString(hex_).size(), stdout);
+      // Print out DebugStrings. Can include non-terminating null characters.
+      const std::string debug_string = cfd->current()->DebugString(hex_);
+      fwrite(debug_string.data(), sizeof(char), debug_string.size(), stdout);
+    } else {
+      for (int level = 0; level < cfd->current()->storage_info()->num_levels();
+           ++level) {
+        const auto& files = cfd->current()->storage_info()->LevelFiles(level);
+        for (const FileMetaData* file : files) {
+          if (file->fd.GetNumber() != sst_file_number_) {
+            continue;
+          }
+
+          found = true;
+          fprintf(stdout,
+                  "--------------- Column family \"%s\"  (ID %" PRIu32
+                  ") --------------\n",
+                  cfd->GetName().c_str(), cfd->GetID());
+          const std::string debug_string = file->DebugString(hex_);
+          fwrite(debug_string.data(), sizeof(char), debug_string.size(),
+                 stdout);
+          fprintf(stdout, " at level %d\n", level);
+          break;
+        }
+        if (found) {
+          break;
+        }
+      }
+      if (found) {
+        break;
+      }
+    }
   }
-  fprintf(stdout,
-          "next_file_number %" PRIu64 " last_sequence %" PRIu64
-          "  prev_log_number %" PRIu64 " max_column_family %" PRIu32
-          " min_log_number_to_keep %" PRIu64 "\n",
-          version_set_->current_next_file_number(),
-          version_set_->LastSequence(), version_set_->prev_log_number(),
-          version_set_->column_family_set_->GetMaxColumnFamily(),
-          version_set_->min_log_number_to_keep());
+  if (sst_file_number_ != 0 && !found) {
+    *s = Status::NotFound("SST file " + std::to_string(sst_file_number_) +
+                          " is not in the live files of the MANIFEST");
+  }
+  if (sst_file_number_ == 0) {
+    fprintf(stdout,
+            "next_file_number %" PRIu64 " last_sequence %" PRIu64
+            "  prev_log_number %" PRIu64 " max_column_family %" PRIu32
+            " min_log_number_to_keep %" PRIu64 "\n",
+            version_set_->current_next_file_number(),
+            version_set_->LastSequence(), version_set_->prev_log_number(),
+            version_set_->column_family_set_->GetMaxColumnFamily(),
+            version_set_->min_log_number_to_keep());
+  }
 }
 
 }  // namespace ROCKSDB_NAMESPACE

--- a/db/version_edit_handler.h
+++ b/db/version_edit_handler.h
@@ -304,7 +304,7 @@ class DumpManifestHandler : public VersionEditHandler {
                       VersionSet* version_set,
                       const std::shared_ptr<IOTracer>& io_tracer,
                       const ReadOptions& read_options, bool verbose, bool hex,
-                      bool json)
+                      bool json, uint64_t sst_file_number)
       : VersionEditHandler(
             /*read_only=*/true, column_families, version_set,
             /*track_missing_files=*/false,
@@ -313,6 +313,7 @@ class DumpManifestHandler : public VersionEditHandler {
         verbose_(verbose),
         hex_(hex),
         json_(json),
+        sst_file_number_(sst_file_number),
         count_(0) {
     cf_to_cmp_names_.reset(new std::unordered_map<uint32_t, std::string>());
   }
@@ -321,11 +322,11 @@ class DumpManifestHandler : public VersionEditHandler {
 
   Status ApplyVersionEdit(VersionEdit& edit, ColumnFamilyData** cfd) override {
     // Write out each individual edit
-    if (verbose_ && !json_) {
+    if (sst_file_number_ == 0 && verbose_ && !json_) {
       // Print out DebugStrings. Can include non-terminating null characters.
       fwrite(edit.DebugString(hex_).data(), sizeof(char),
              edit.DebugString(hex_).size(), stdout);
-    } else if (json_) {
+    } else if (sst_file_number_ == 0 && json_) {
       // Print out DebugStrings. Can include non-terminating null characters.
       fwrite(edit.DebugString(hex_).data(), sizeof(char),
              edit.DebugString(hex_).size(), stdout);
@@ -340,6 +341,7 @@ class DumpManifestHandler : public VersionEditHandler {
   const bool verbose_;
   const bool hex_;
   const bool json_;
+  const uint64_t sst_file_number_;
   int count_;
 };
 

--- a/db/version_set.cc
+++ b/db/version_set.cc
@@ -4952,23 +4952,7 @@ std::string Version::DebugString(bool hex, bool print_stats) const {
     const std::vector<FileMetaData*>& files = storage_info_->files_[level];
     for (size_t i = 0; i < files.size(); i++) {
       r.push_back(' ');
-      AppendNumberTo(&r, files[i]->fd.GetNumber());
-      r.push_back(':');
-      AppendNumberTo(&r, files[i]->fd.GetFileSize());
-      r.append("[");
-      AppendNumberTo(&r, files[i]->fd.smallest_seqno);
-      r.append(" .. ");
-      AppendNumberTo(&r, files[i]->fd.largest_seqno);
-      r.append("]");
-      r.append("[");
-      r.append(files[i]->smallest.DebugString(hex));
-      r.append(" .. ");
-      r.append(files[i]->largest.DebugString(hex));
-      r.append("]");
-      if (files[i]->oldest_blob_file_number != kInvalidBlobFileNumber) {
-        r.append(" blob_file:");
-        AppendNumberTo(&r, files[i]->oldest_blob_file_number);
-      }
+      r.append(files[i]->DebugString(hex));
       if (print_stats) {
         r.append("(");
         r.append(std::to_string(
@@ -6412,7 +6396,8 @@ Status VersionSet::GetLiveFilesChecksumInfo(FileChecksumList* checksum_list) {
 
 Status VersionSet::DumpManifest(
     Options& options, std::string& dscname, bool verbose, bool hex, bool json,
-    const std::vector<ColumnFamilyDescriptor>& cf_descs) {
+    const std::vector<ColumnFamilyDescriptor>& cf_descs,
+    uint64_t sst_file_number) {
   assert(options.env);
   // TODO: plumb Env::IOActivity
   const ReadOptions read_options;
@@ -6453,7 +6438,7 @@ Status VersionSet::DumpManifest(
   }
 
   DumpManifestHandler handler(final_cf_descs, this, io_tracer_, read_options,
-                              verbose, hex, json);
+                              verbose, hex, json, sst_file_number);
   {
     VersionSet::LogReporter reporter;
     reporter.status = &s;

--- a/db/version_set.h
+++ b/db/version_set.h
@@ -1294,10 +1294,12 @@ class VersionSet {
   // Get the checksum information of all live files
   Status GetLiveFilesChecksumInfo(FileChecksumList* checksum_list);
 
-  // printf contents (for debugging)
+  // Print contents for debugging. If sst_file_number is nonzero, only print
+  // the final metadata for that live SST.
   Status DumpManifest(Options& options, std::string& manifestFileName,
                       bool verbose, bool hex = false, bool json = false,
-                      const std::vector<ColumnFamilyDescriptor>& cf_descs = {});
+                      const std::vector<ColumnFamilyDescriptor>& cf_descs = {},
+                      uint64_t sst_file_number = 0);
 
   const std::string& DbSessionId() const { return db_session_id_; }
 

--- a/tools/ldb_cmd.cc
+++ b/tools/ldb_cmd.cc
@@ -1349,7 +1349,8 @@ namespace {
 
 void DumpManifestFile(Options options, std::string file, bool verbose, bool hex,
                       bool json,
-                      const std::vector<ColumnFamilyDescriptor>& cf_descs) {
+                      const std::vector<ColumnFamilyDescriptor>& cf_descs,
+                      uint64_t sst_file_number = 0) {
   EnvOptions sopt;
   std::string dbname("dummy");
   std::shared_ptr<Cache> tc(NewLRUCache(options.max_open_files - 10,
@@ -1367,7 +1368,8 @@ void DumpManifestFile(Options options, std::string file, bool verbose, bool hex,
                       /*db_id=*/"", /*db_session_id=*/"",
                       options.daily_offpeak_time_utc,
                       /*error_handler=*/nullptr);
-  Status s = versions.DumpManifest(options, file, verbose, hex, json, cf_descs);
+  Status s = versions.DumpManifest(options, file, verbose, hex, json, cf_descs,
+                                   sst_file_number);
   if (!s.ok()) {
     fprintf(stderr, "Error in processing file %s %s\n", file.c_str(),
             s.ToString().c_str());
@@ -1379,6 +1381,7 @@ void DumpManifestFile(Options options, std::string file, bool verbose, bool hex,
 const std::string ManifestDumpCommand::ARG_VERBOSE = "verbose";
 const std::string ManifestDumpCommand::ARG_JSON = "json";
 const std::string ManifestDumpCommand::ARG_PATH = "path";
+const std::string ManifestDumpCommand::ARG_NUMBER = "sst_file_number";
 
 void ManifestDumpCommand::Help(std::string& ret) {
   ret.append("  ");
@@ -1386,6 +1389,7 @@ void ManifestDumpCommand::Help(std::string& ret) {
   ret.append(" [--" + ARG_VERBOSE + "]");
   ret.append(" [--" + ARG_JSON + "]");
   ret.append(" [--" + ARG_PATH + "=<path_to_manifest_file>]");
+  ret.append(" [--" + ARG_NUMBER + "=<sst_file_number>]");
   ret.append("\n");
 }
 
@@ -1393,11 +1397,12 @@ ManifestDumpCommand::ManifestDumpCommand(
     const std::vector<std::string>& /*params*/,
     const std::map<std::string, std::string>& options,
     const std::vector<std::string>& flags)
-    : LDBCommand(
-          options, flags, false,
-          BuildCmdLineOptions({ARG_VERBOSE, ARG_PATH, ARG_HEX, ARG_JSON})),
+    : LDBCommand(options, flags, false,
+                 BuildCmdLineOptions(
+                     {ARG_VERBOSE, ARG_PATH, ARG_HEX, ARG_JSON, ARG_NUMBER})),
       verbose_(false),
-      json_(false) {
+      json_(false),
+      sst_file_number_(0) {
   verbose_ = IsFlagPresent(flags, ARG_VERBOSE);
   json_ = IsFlagPresent(flags, ARG_JSON);
 
@@ -1406,6 +1411,23 @@ ManifestDumpCommand::ManifestDumpCommand(
     path_ = itr->second;
     if (path_.empty()) {
       exec_state_ = LDBCommandExecuteResult::Failed("--path: missing pathname");
+    }
+  }
+
+  if (IsFlagPresent(flags, ARG_NUMBER)) {
+    exec_state_ =
+        LDBCommandExecuteResult::Failed("--sst_file_number requires a value");
+  } else {
+    itr = options.find(ARG_NUMBER);
+    if (itr != options.end()) {
+      Slice value(itr->second);
+      if (!ConsumeDecimalNumber(&value, &sst_file_number_) || !value.empty()) {
+        exec_state_ = LDBCommandExecuteResult::Failed(
+            "--sst_file_number must be an unsigned 64-bit decimal integer");
+      } else if (sst_file_number_ == 0) {
+        exec_state_ = LDBCommandExecuteResult::Failed(
+            "--sst_file_number must be greater than zero");
+      }
     }
   }
 }
@@ -1480,7 +1502,7 @@ void ManifestDumpCommand::DoCommand() {
   }
 
   DumpManifestFile(options_, manifestfile, verbose_, is_key_hex_, json_,
-                   column_families_);
+                   column_families_, sst_file_number_);
 
   if (verbose_) {
     fprintf(stdout, "Processing Manifest file %s done\n", manifestfile.c_str());

--- a/tools/ldb_cmd_impl.h
+++ b/tools/ldb_cmd_impl.h
@@ -193,10 +193,12 @@ class ManifestDumpCommand : public LDBCommand {
   bool verbose_;
   bool json_;
   std::string path_;
+  uint64_t sst_file_number_;
 
   static const std::string ARG_VERBOSE;
   static const std::string ARG_JSON;
   static const std::string ARG_PATH;
+  static const std::string ARG_NUMBER;
 };
 
 class UpdateManifestCommand : public LDBCommand {

--- a/tools/ldb_test.py
+++ b/tools/ldb_test.py
@@ -826,6 +826,105 @@ class LDBTestCase(unittest.TestCase):
             cmd_verbose, expected_verbose_output, unexpected=False, isPattern=True
         )
 
+    def testManifestDumpSstFileNumber(self):
+        print("Running testManifestDumpSstFileNumber...")
+        dbPath = os.path.join(self.TMP_DIR, self.DB_NAME)
+        self.assertRunOK("put default-key default-value --create_if_missing", "OK")
+        self.assertRunOK("create_column_family write", "OK")
+        self.assertRunOK(
+            "put --column_family=write write-key write-value", "OK"
+        )
+        self.assertRunOK(
+            "put --column_family=write write-key-2 write-value-2", "OK"
+        )
+
+        help_output = my_check_output("./ldb --help", shell=True)
+        self.assertIn("--sst_file_number=<sst_file_number>", help_output)
+
+        live_files_output = my_check_output(
+            "./ldb list_live_files_metadata --sort_by_filename --db=%s" % dbPath,
+            shell=True,
+        )
+        write_file = re.search(
+            r"(\d+)\.sst : level (\d+), column family 'write'",
+            live_files_output,
+        )
+        self.assertIsNotNone(write_file)
+        sst_file_number = int(write_file.group(1))
+        expected_level = write_file.group(2)
+
+        output = my_check_output(
+            './ldb manifest_dump --hex --db=%s --sst_file_number=%d '
+            '| grep -v "Created bg thread"' % (dbPath, sst_file_number),
+            shell=True,
+        ).strip()
+        output_lines = output.splitlines()
+        self.assertEqual(len(output_lines), 2)
+        self.assertRegex(
+            output_lines[0],
+            r'^--------------- Column family "write"  \(ID \d+\) --------------$',
+        )
+        self.assertRegex(
+            output_lines[1],
+            r"^%d:\d+\[\d+ \.\. \d+\]"
+            r"\[.+ seq:\d+, type:\d+ \.\. .+ seq:\d+, type:\d+\]"
+            r" at level %s$" % (sst_file_number, expected_level),
+        )
+
+        output_with_leading_zeros = my_check_output(
+            './ldb manifest_dump --hex --db=%s --sst_file_number=%020d '
+            '| grep -v "Created bg thread"' % (dbPath, sst_file_number),
+            shell=True,
+        ).strip()
+        self.assertEqual(output_with_leading_zeros, output)
+
+        invalid_sst_file_numbers = [
+            "",
+            "0",
+            "not-a-number",
+            "-1",
+            "+1",
+            " 1",
+            "1k",
+            "123abc",
+            "18446744073709551616",
+        ]
+        for invalid_sst_file_number in invalid_sst_file_numbers:
+            process = subprocess.Popen(
+                [
+                    "./ldb",
+                    "manifest_dump",
+                    "--db=%s" % dbPath,
+                    "--sst_file_number=%s" % invalid_sst_file_number,
+                ],
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+            )
+            stdout, stderr = process.communicate()
+            self.assertNotEqual(process.returncode, 0)
+            self.assertEqual(stdout.decode("utf-8").strip(), "")
+            self.assertIn("Failed: --sst_file_number", stderr.decode("utf-8"))
+
+        self.assertRunOK("drop_column_family write", "OK")
+        output = my_check_output(
+            "./ldb manifest_dump --db=%s --sst_file_number=%d"
+            % (dbPath, sst_file_number),
+            shell=True,
+        )
+        self.assertEqual(output.strip(), "")
+
+        all_sst_file_numbers = [
+            int(os.path.basename(path).split(".")[0])
+            for path in self.getSSTFiles(dbPath)
+        ]
+        missing_sst_file_number = max(all_sst_file_numbers) + 1
+        output = my_check_output(
+            "./ldb manifest_dump --db=%s --sst_file_number=%d"
+            % (dbPath, missing_sst_file_number),
+            shell=True,
+        )
+        self.assertEqual(output.strip(), "")
+
     def testGetProperty(self):
         print("Running testGetProperty...")
         dbPath = os.path.join(self.TMP_DIR, self.DB_NAME)


### PR DESCRIPTION
## What problem does this PR solve?

Related issue: [tikv/tikv#19873](https://github.com/tikv/tikv/issues/19873)

When `tikv-ctl bad-ssts` finds a corrupted SST, it invokes:

```text
ldb --hex manifest_dump \
  --db=<rocksdb-path> \
  --sst_file_number=<corrupted-sst-number>
```

RocksDB `8.10.tikv` no longer supports `--sst_file_number`, causing the command to fail with:

```text
Invalid command-line option sst_file_number
```

This functionality previously existed on the `6.29.tikv` branch:

- Original PR: [tikv/rocksdb#247](https://github.com/tikv/rocksdb/pull/247)
- Original commit: `e1797a06ab03560622b8884a8d8f873a0dc6fbe8`

It was not carried over during the upgrade to `8.10.tikv`.

## What is changed?

This PR ports the feature to the current RocksDB implementation:

- Adds `--sst_file_number=<sst_file_number>` to `manifest_dump`.
- Passes the option through `ManifestDumpCommand`, `VersionSet::DumpManifest`, and `DumpManifestHandler`.
- Replays the complete MANIFEST before looking up the SST, so only its final live metadata is reported.
- Searches across all column families and prints the column family containing the target SST.
- Prints the SST number, file size, sequence number range, internal key range, and level.
- Produces no unrelated SST metadata when the requested SST does not exist or is no longer live.
- Keeps the existing full MANIFEST dump behavior unchanged when the option is not specified.
- Adds an ldb test covering help output, multiple column families, metadata output, and a missing SST number.

The implementation follows the current 8.10 APIs instead of directly cherry-picking the old patch.

## Tests

Test coverage has been added in `tools/ldb_test.py`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an `--sst_file_number` option to `manifest_dump` to scope output to a single matching live SST file instead of dumping all metadata.
  * When set (and nonzero), output includes only the matched SST file’s debug metadata (respects `--hex`, including optional blob-file details when present).
  * If no matching SST file is found or the corresponding column family was dropped, `manifest_dump` returns empty output (and invalid values fail).

* **Tests**
  * Added coverage for `manifest_dump --sst_file_number`, including exact output structure/level and empty output for missing or dropped SST files, plus validation of invalid inputs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->