### PR TITLE
CP: Limit compaction input files expansion- #12484

### DIFF
--- a/db/compaction/compaction_picker.cc
+++ b/db/compaction/compaction_picker.cc
@@ -500,7 +500,16 @@ bool CompactionPicker::SetupOtherInputs(
   // user key, while excluding other entries for the same user key. This
   // can happen when one user key spans multiple files.
   if (!output_level_inputs->empty()) {
-    const uint64_t limit = mutable_cf_options.max_compaction_bytes;
+    // It helps to reduce write amp and avoid a further separate compaction
+    // to include more input level files without expanding output level files.
+    // So we apply a softer limit when the strict max_compaction_bytes limit is
+    // configured to be ignored. We still need a limit to avoid overly large
+    // compactions and potential high space amp spikes.
+    const uint64_t limit =
+        mutable_cf_options.ignore_max_compaction_bytes_for_input
+            ? MultiplyCheckOverflow(mutable_cf_options.max_compaction_bytes,
+                                    2.0)
+            : mutable_cf_options.max_compaction_bytes;
     const uint64_t output_level_inputs_size =
         TotalFileSize(output_level_inputs->files);
     const uint64_t inputs_size = TotalFileSize(inputs->files);
@@ -527,9 +536,8 @@ bool CompactionPicker::SetupOtherInputs(
       try_overlapping_inputs = false;
     }
     if (try_overlapping_inputs && expanded_inputs.size() > inputs->size() &&
-        (mutable_cf_options.ignore_max_compaction_bytes_for_input ||
-         output_level_inputs_size + expanded_inputs_size < limit) &&
-        !AreFilesInCompaction(expanded_inputs.files)) {
+        !AreFilesInCompaction(expanded_inputs.files) &&
+        output_level_inputs_size + expanded_inputs_size < limit) {
       InternalKey new_start, new_limit;
       GetRange(expanded_inputs, &new_start, &new_limit);
       CompactionInputFiles expanded_output_level_inputs;
@@ -551,9 +559,8 @@ bool CompactionPicker::SetupOtherInputs(
                                              base_index, nullptr);
       expanded_inputs_size = TotalFileSize(expanded_inputs.files);
       if (expanded_inputs.size() > inputs->size() &&
-          (mutable_cf_options.ignore_max_compaction_bytes_for_input ||
-           output_level_inputs_size + expanded_inputs_size < limit) &&
-          !AreFilesInCompaction(expanded_inputs.files)) {
+          !AreFilesInCompaction(expanded_inputs.files) &&
+          (output_level_inputs_size + expanded_inputs_size) < limit) {
         expand_inputs = true;
       }
     }

--- a/db/compaction/compaction_picker.cc
+++ b/db/compaction/compaction_picker.cc
@@ -534,6 +534,8 @@ bool CompactionPicker::SetupOtherInputs(
     uint64_t expanded_inputs_size = TotalFileSize(expanded_inputs.files);
     if (!ExpandInputsToCleanCut(cf_name, vstorage, &expanded_inputs)) {
       try_overlapping_inputs = false;
+    } else {
+      expanded_inputs_size = TotalFileSize(expanded_inputs.files);
     }
     if (try_overlapping_inputs && expanded_inputs.size() > inputs->size() &&
         !AreFilesInCompaction(expanded_inputs.files) &&

--- a/db/compaction/compaction_picker.cc
+++ b/db/compaction/compaction_picker.cc
@@ -535,6 +535,8 @@ bool CompactionPicker::SetupOtherInputs(
     if (!ExpandInputsToCleanCut(cf_name, vstorage, &expanded_inputs)) {
       try_overlapping_inputs = false;
     } else {
+      // Clean-cut expansion may add boundary files, so use the final size when
+      // enforcing the compaction byte limit below.
       expanded_inputs_size = TotalFileSize(expanded_inputs.files);
     }
     if (try_overlapping_inputs && expanded_inputs.size() > inputs->size() &&

--- a/db/compaction/compaction_picker_test.cc
+++ b/db/compaction/compaction_picker_test.cc
@@ -2526,6 +2526,7 @@ TEST_F(CompactionPickerTest, MaxCompactionBytesNotHit) {
 TEST_F(CompactionPickerTest, CompactionLimitWhenAddFileFromInputLevel) {
   mutable_cf_options_.max_bytes_for_level_base = 1000000u;
   mutable_cf_options_.max_compaction_bytes = 800000u;
+  mutable_cf_options_.ignore_max_compaction_bytes_for_input = true;
   ioptions_.level_compaction_dynamic_level_bytes = false;
   NewVersionStorage(6, kCompactionStyleLevel);
   // A compaction should be triggered and pick file 2 and 5.
@@ -2561,6 +2562,7 @@ TEST_F(CompactionPickerTest, CompactionLimitWhenAddFileFromInputLevel) {
 TEST_F(CompactionPickerTest, HitCompactionLimitWhenAddFileFromInputLevel) {
   mutable_cf_options_.max_bytes_for_level_base = 1000000u;
   mutable_cf_options_.max_compaction_bytes = 800000u;
+  mutable_cf_options_.ignore_max_compaction_bytes_for_input = true;
   ioptions_.level_compaction_dynamic_level_bytes = false;
   NewVersionStorage(6, kCompactionStyleLevel);
   // A compaction should be triggered and pick file 2 and 5.
@@ -2588,6 +2590,34 @@ TEST_F(CompactionPickerTest, HitCompactionLimitWhenAddFileFromInputLevel) {
   ASSERT_EQ(1U, compaction->num_input_files(1));
   ASSERT_EQ(2U, compaction->input(0, 0)->fd.GetNumber());
   ASSERT_EQ(5U, compaction->input(1, 0)->fd.GetNumber());
+}
+
+TEST_F(CompactionPickerTest, CleanCutExpansionRespectsSoftLimit) {
+  mutable_cf_options_.max_bytes_for_level_base = 1000u;
+  mutable_cf_options_.max_compaction_bytes = 800u;
+  mutable_cf_options_.ignore_max_compaction_bytes_for_input = true;
+  ioptions_.level_compaction_dynamic_level_bytes = false;
+  NewVersionStorage(6, kCompactionStyleLevel);
+
+  // File 1 is selected first. The output-level range pulls in file 2, and the
+  // initial expanded size is below 2 * max_compaction_bytes. Expanding to a
+  // clean user-key boundary then pulls in file 3, taking the actual input plus
+  // output size above the limit.
+  Add(1, 1U, "151", "200", 1U, 0, 100, 100, 2000U);
+  Add(1, 2U, "201", "250", 600U, 0, 100, 100, 1U);
+  Add(1, 3U, "250", "300", 1000U, 0, 100, 100, 1U);
+  Add(2, 4U, "151", "220", 1U);
+  UpdateVersionStorageInfo();
+
+  std::unique_ptr<Compaction> compaction(level_compaction_picker.PickCompaction(
+      cf_name_, mutable_cf_options_, mutable_db_options_, vstorage_.get(),
+      &log_buffer_));
+  ASSERT_TRUE(compaction.get() != nullptr);
+  ASSERT_EQ(2U, compaction->num_input_levels());
+  ASSERT_EQ(1U, compaction->num_input_files(0));
+  ASSERT_EQ(1U, compaction->num_input_files(1));
+  ASSERT_EQ(1U, compaction->input(0, 0)->fd.GetNumber());
+  ASSERT_EQ(4U, compaction->input(1, 0)->fd.GetNumber());
 }
 
 TEST_F(CompactionPickerTest, IsTrivialMoveOn) {

--- a/db/compaction/compaction_picker_test.cc
+++ b/db/compaction/compaction_picker_test.cc
@@ -2523,6 +2523,73 @@ TEST_F(CompactionPickerTest, MaxCompactionBytesNotHit) {
   ASSERT_EQ(5U, compaction->input(1, 0)->fd.GetNumber());
 }
 
+TEST_F(CompactionPickerTest, CompactionLimitWhenAddFileFromInputLevel) {
+  mutable_cf_options_.max_bytes_for_level_base = 1000000u;
+  mutable_cf_options_.max_compaction_bytes = 800000u;
+  ioptions_.level_compaction_dynamic_level_bytes = false;
+  NewVersionStorage(6, kCompactionStyleLevel);
+  // A compaction should be triggered and pick file 2 and 5.
+  // It pulls in other compaction input file from the input level L1
+  // without pulling in more output level files.
+  // Files 1, 3, 4 are eligible.
+  // File 6 is excluded since it overlaps with file 7.
+  // It can expand input level since in this case, the limit on compaction size
+  // is 2 * max_compaction_bytes.
+  Add(1, 1U, "100", "150", 300000U);
+  Add(1, 2U, "151", "200", 300001U, 0, 0);
+  Add(1, 3U, "201", "250", 300000U, 0, 0);
+  Add(1, 4U, "251", "300", 300000U, 0, 0);
+  Add(1, 6U, "325", "400", 300000U, 0, 0);
+  Add(2, 5U, "100", "350", 1U);
+  Add(2, 7U, "375", "425", 1U);
+  UpdateVersionStorageInfo();
+
+  std::unique_ptr<Compaction> compaction(level_compaction_picker.PickCompaction(
+      cf_name_, mutable_cf_options_, mutable_db_options_, vstorage_.get(),
+      &log_buffer_));
+  ASSERT_TRUE(compaction.get() != nullptr);
+  ASSERT_EQ(2U, compaction->num_input_levels());
+  ASSERT_EQ(4U, compaction->num_input_files(0));
+  ASSERT_EQ(1U, compaction->num_input_files(1));
+  ASSERT_EQ(1U, compaction->input(0, 0)->fd.GetNumber());
+  ASSERT_EQ(2U, compaction->input(0, 1)->fd.GetNumber());
+  ASSERT_EQ(3U, compaction->input(0, 2)->fd.GetNumber());
+  ASSERT_EQ(4U, compaction->input(0, 3)->fd.GetNumber());
+  ASSERT_EQ(5U, compaction->input(1, 0)->fd.GetNumber());
+}
+
+TEST_F(CompactionPickerTest, HitCompactionLimitWhenAddFileFromInputLevel) {
+  mutable_cf_options_.max_bytes_for_level_base = 1000000u;
+  mutable_cf_options_.max_compaction_bytes = 800000u;
+  ioptions_.level_compaction_dynamic_level_bytes = false;
+  NewVersionStorage(6, kCompactionStyleLevel);
+  // A compaction should be triggered and pick file 2 and 5.
+  // It pulls in other compaction input file from the input level L1
+  // without pulling in more output level files.
+  // Files 1, 3, 4 are eligible.
+  // File 6 is excluded since it overlaps with file 7.
+  // It can not expand input level since total compaction size hit the limit
+  // 2 * max_compaction_bytes.
+  Add(1, 1U, "100", "150", 400000U);
+  Add(1, 2U, "151", "200", 400001U, 0, 0);
+  Add(1, 3U, "201", "250", 400000U, 0, 0);
+  Add(1, 4U, "251", "300", 400000U, 0, 0);
+  Add(1, 6U, "325", "400", 400000U, 0, 0);
+  Add(2, 5U, "100", "350", 1U);
+  Add(2, 7U, "375", "425", 1U);
+  UpdateVersionStorageInfo();
+
+  std::unique_ptr<Compaction> compaction(level_compaction_picker.PickCompaction(
+      cf_name_, mutable_cf_options_, mutable_db_options_, vstorage_.get(),
+      &log_buffer_));
+  ASSERT_TRUE(compaction.get() != nullptr);
+  ASSERT_EQ(2U, compaction->num_input_levels());
+  ASSERT_EQ(1U, compaction->num_input_files(0));
+  ASSERT_EQ(1U, compaction->num_input_files(1));
+  ASSERT_EQ(2U, compaction->input(0, 0)->fd.GetNumber());
+  ASSERT_EQ(5U, compaction->input(1, 0)->fd.GetNumber());
+}
+
 TEST_F(CompactionPickerTest, IsTrivialMoveOn) {
   mutable_cf_options_.max_bytes_for_level_base = 10000u;
   mutable_cf_options_.max_compaction_bytes = 10001u;
@@ -4151,7 +4218,6 @@ TEST_P(PerKeyPlacementCompactionPickerTest,
 
 INSTANTIATE_TEST_CASE_P(PerKeyPlacementCompactionPickerTest,
                         PerKeyPlacementCompactionPickerTest, ::testing::Bool());
-
 
 }  // namespace ROCKSDB_NAMESPACE
 

--- a/include/rocksdb/advanced_options.h
+++ b/include/rocksdb/advanced_options.h
@@ -725,15 +725,14 @@ struct AdvancedColumnFamilyOptions {
   // Dynamically changeable through SetOptions() API
   uint64_t max_compaction_bytes = 0;
 
-  // When setting up compaction input files, we ignore the
-  // `max_compaction_bytes` limit when pulling in input files that are entirely
-  // within output key range.
+  // When setting up compaction input files, use a softer limit of
+  // 2 * `max_compaction_bytes` when pulling in input files that are entirely
+  // within the output key range. If false, use the strict
+  // `max_compaction_bytes` limit instead.
   //
   // Default: true
   //
   // Dynamically changeable through SetOptions() API
-  // We could remove this knob and always ignore the limit once it is proven
-  // safe.
   bool ignore_max_compaction_bytes_for_input = true;
 
   // All writes will be slowed down to at least delayed_write_rate if estimated


### PR DESCRIPTION
## Summary

Backport [facebook/rocksdb#12484](https://github.com/facebook/rocksdb/pull/12484) to the `8.10.tikv` branch.

This change limits optional input-level expansion during compaction:

- `ignore_max_compaction_bytes_for_input=false` retains the strict 1x `max_compaction_bytes` limit.
- `ignore_max_compaction_bytes_for_input=true` applies a softer 2x limit instead of allowing effectively unbounded expansion.

## Changes

- Apply the softer compaction input expansion limit from upstream.
- Recalculate the selected input size after clean-cut expansion, ensuring the limit is checked against the final SST set.
- Update the public option documentation to describe the branch-specific 1x/2x behavior.
- Add `CleanCutExpansionRespectsSoftLimit` to cover clean-cut expansion crossing the soft limit.

## Testing

- `make -j4 compaction_picker_test`
- Five relevant compaction picker tests passed.
- `clang-format --dry-run --Werror` passed.
- `git diff --check` passed.
- Full suite result: 116/119 tests passed. The remaining three failures are existing order-dependent SyncPoint callback isolation failures unrelated to this change.

## Review Status

The previously identified clean-cut size-accounting and documentation issues have been fixed.

Two follow-ups were identified during the final review:

- Use overflow-safe arithmetic when comparing the combined input and output sizes against the limit.
- Add an unreleased behavior-change note documenting the new default 2x cap.

No additional data-correctness or security issue was found.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved compaction input selection to enforce a finite expansion limit when the maximum input-size override is enabled.
  * Prevented overlapping and clean-cut compactions from exceeding the applicable size limit.

* **Documentation**
  * Clarified how compaction input-size limits are applied, including the soft limit of twice the configured maximum.
  * Documented that the setting remains enabled by default and can be changed dynamically.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->